### PR TITLE
fix: handle port forwarding on etfw gracefully

### DIFF
--- a/common/k8s_portforward/port-forward.go
+++ b/common/k8s_portforward/port-forward.go
@@ -395,6 +395,20 @@ func PortForwardService(svcName string, namespace string, port int) (string, err
 }
 
 func TryPortForwardNode(address string, port int) string {
+	// On some deployments port forwarding is not enabled
+	enabled := false
+	val, defined := os.LookupEnv("e2e_port_forwarding_enabled")
+	if defined {
+		switch val {
+		case "True", "true", "Yes", "yes", "y", "Y", "1":
+			enabled = true
+		default:
+			enabled = false
+		}
+	}
+	if !enabled {
+		return fmt.Sprintf("%s:%d", address, port)
+	}
 	addrPort, err := PortForwardNode(address, port)
 	if err != nil {
 		log.Log.Info(fmt.Sprintf("TryPortForwardNode: falling back to %s:%v", address, port))


### PR DESCRIPTION
The e2e port forwarding scheme only works if e2e-agent and e2e-proxy are installed in the cluster. Change the stance so that port forwarding must be
enabled explictly.
Enablement is controlled environment variable setting e2e_port_forwarding_enabled to True If the environment variable is not set then port forwarding is off.