### PR TITLE
chore: build and push e2e tools to openebs dockerub

### DIFF
--- a/common/e2e_config/e2e_config.go
+++ b/common/e2e_config/e2e_config.go
@@ -159,7 +159,7 @@ type E2EConfig struct {
 	ImagePullPolicy              string `yaml:"imagePullPolicy" env-default:"IfNotPresent" env:"e2e_image_pull_policy"`
 	InstallLoki                  bool   `yaml:"installLoki" env-default:"true" env:"install_loki"`
 	LokiStatefulsetOnControlNode bool   `yaml:"lokiOnControlNode" env-default:"true" env:"loki_on_control_node"`
-	E2eFioImage                  string `yaml:"e2eFioImage" env-default:"openebs/e2e-fio:v3.36-e2e-8" env:"e2e_fio_image"`
+	E2eFioImage                  string `yaml:"e2eFioImage" env-default:"openebs/e2e-fio:v3.37-e2e-0" env:"e2e_fio_image"`
 	SetSafeMountAlways           bool   `yaml:"setSafeMountAlways" env-default:"false" env:"safe_mount_always"`
 	// This is an advisory setting for individual tests
 	// If set to true - typically during test development - tests with multiple 'It' clauses should defer asserts till after

--- a/tools/e2e-agent/README.md
+++ b/tools/e2e-agent/README.md
@@ -6,7 +6,7 @@ This agent runs as a daemonset in the cluster to help run commands remotely.
 
 ## Building
 Run `./build.sh`
-This builds the image `mayadata/e2e-agent`
+This builds the image `openebs/e2e-agent`
 
 # Deploying
 The e2e-agent yaml includes a configmap and the e2e-agent daemonset definition.

--- a/tools/e2e-agent/build.sh
+++ b/tools/e2e-agent/build.sh
@@ -8,8 +8,8 @@
 # This works for legacy test runs and also other test frameworks
 # as long as we do not make breaking changes.
 set -e
-IMAGE="mayadata/e2e-agent"
-TAG="v2.7.0"
+IMAGE="openebs/e2e-agent"
+TAG="v2.8.0"
 registry=""
 tag_as_latest=""
 
@@ -33,18 +33,23 @@ done
 
 if docker build -t ${IMAGE} --build-arg GO_VERSION=1.19.3 --build-arg E2EA_VERSION=${TAG} . ; then
     if [ "${registry}" != "" ]; then
-        if [ "${tag_as_latest}" == "Y" ];  then
-            echo "tagging as latest and pushing image"
-            docker tag ${IMAGE} $registry/${IMAGE}
-            docker push $registry/${IMAGE}
-        fi
-        if [ "${TAG}" != "" ];  then
-            echo "tagging as ${TAG} and pushing image"
-            docker tag ${IMAGE} $registry/${IMAGE}:${TAG}
-            docker push $registry/${IMAGE}:${TAG}
-        else
-            echo "TAG was not defined - image not retagged and pushed"
-        fi
+        echo "image registry: ${registry}"
+        AGENT_IMAGE="${registry}/${IMAGE}"
+    else
+        echo "image registry: dockerhub"
+        AGENT_IMAGE="${IMAGE}"
+    fi
+    if [ "${tag_as_latest}" == "Y" ];  then
+        echo "tagging as latest and push image ${AGENT_IMAGE}"
+        docker tag ${IMAGE} ${AGENT_IMAGE}
+        docker push ${AGENT_IMAGE}
+    fi
+    if [ "${TAG}" != "" ];  then
+        echo "tagging as ${TAG} and push image  ${AGENT_IMAGE}"
+        docker tag ${IMAGE} ${AGENT_IMAGE}:${TAG}
+        docker push ${AGENT_IMAGE}:${TAG}
+    else
+        echo "TAG was not defined - image not retagged and pushed"
     fi
 else
     exit 1

--- a/tools/e2e-agent/e2e-agent.yaml
+++ b/tools/e2e-agent/e2e-agent.yaml
@@ -41,7 +41,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: openebs/e2e-agent:v2.7.0
+          image: openebs/e2e-agent:v2.8.0
           imagePullPolicy: Always
           volumeMounts:
             - name: host-root

--- a/tools/e2e-fio/Dockerfile
+++ b/tools/e2e-fio/Dockerfile
@@ -1,10 +1,10 @@
 # VERSION 0.1
 FROM alpine:edge
 
-MAINTAINER mayastor mayastor@mayadata.io
+MAINTAINER openebs openebs@openebs.io
 
 RUN apk --no-cache add \
-    	fio=3.36-r0 gcc musl-dev
+    	fio=3.37-r0 gcc musl-dev
 
 ADD e2e_fio.c /
 ADD liveness.c /

--- a/tools/e2e-fio/README.md
+++ b/tools/e2e-fio/README.md
@@ -76,4 +76,4 @@ For legacy compatibility where implicit start of a new option is detected
 ## building
 Run `./build.sh`
 
-This builds the image `mayadata/e2e-fio`
+This builds the image `openebs/e2e-fio`

--- a/tools/e2e-fio/build.sh
+++ b/tools/e2e-fio/build.sh
@@ -10,8 +10,8 @@
 # The exception to this rule is the e2e-fio image, only to correct
 # existing semantics.
 set -e
-IMAGE="mayadata/e2e-fio"
-TAG="v3.36-e2e-8"
+IMAGE="openebs/e2e-fio"
+TAG="v3.37-e2e-0"
 registry=""
 tag_as_latest=""
 
@@ -38,18 +38,23 @@ echo "#define VERSION \"$TAG\"" > e2e_fio_version.h
 # Note always builds image with latest tag in local registry
 if docker build -t ${IMAGE} . ; then
     if [ "${registry}" != "" ]; then
-        if [ "${tag_as_latest}" == "Y" ];  then
-            echo "tagging as latest and pushing image"
-            docker tag ${IMAGE} $registry/${IMAGE}
-            docker push $registry/${IMAGE}
-        fi
-        if [ "${TAG}" != "" ];  then
-            echo "tagging as ${TAG} and pushing image"
-            docker tag ${IMAGE} $registry/${IMAGE}:${TAG}
-            docker push $registry/${IMAGE}:${TAG}
-        else
-            echo "TAG was not defined - image not retagged and pushed"
-        fi
+        echo "image registry: ${registry}"
+        FIO_IMAGE="${registry}/${IMAGE}"
+    else
+        echo "image registry: dockerhub"
+        FIO_IMAGE="${IMAGE}"
+    fi
+    if [ "${tag_as_latest}" == "Y" ];  then
+        echo "tagging as latest and push image ${FIO_IMAGE}"
+        docker tag ${IMAGE} ${FIO_IMAGE}
+        docker push ${FIO_IMAGE}
+    fi
+    if [ "${TAG}" != "" ];  then
+        echo "tagging as ${TAG} and push image  ${FIO_IMAGE}"
+        docker tag ${IMAGE} ${FIO_IMAGE}:${TAG}
+        docker push ${FIO_IMAGE}:${TAG}
+    else
+        echo "TAG was not defined - image not retagged and pushed"
     fi
 else
     exit 1

--- a/tools/e2e-proxy/Dockerfile
+++ b/tools/e2e-proxy/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:latest as builder
 
 # Add Maintainer Info
-LABEL maintainer="Datacore"
+LABEL maintainer="openebs"
 
 # Set the Current Working Directory inside the container
 WORKDIR /app

--- a/tools/e2e-proxy/build.sh
+++ b/tools/e2e-proxy/build.sh
@@ -8,7 +8,7 @@
 # This works for legacy test runs and also other test frameworks
 # as long as we do not make breaking changes.
 set -e
-IMAGE="mayadata/e2e-proxy"
+IMAGE="openebs/e2e-proxy"
 TAG="v1.0.0"
 registry=""
 tag_as_latest=""
@@ -33,18 +33,23 @@ done
 
 if docker build -t ${IMAGE} --build-arg GO_VERSION=1.19.3 . ; then
     if [ "${registry}" != "" ]; then
-        if [ "${tag_as_latest}" == "Y" ];  then
-            echo "tagging as latest and pushing image"
-            docker tag ${IMAGE} $registry/${IMAGE}
-            docker push $registry/${IMAGE}
-        fi
-        if [ "${TAG}" != "" ];  then
-            echo "tagging as ${TAG} and pushing image"
-            docker tag ${IMAGE} $registry/${IMAGE}:${TAG}
-            docker push $registry/${IMAGE}:${TAG}
-        else
-            echo "TAG was not defined - image not retagged and pushed"
-        fi
+        echo "image registry: ${registry}"
+        PROXY_IMAGE="${registry}/${IMAGE}"
+    else
+        echo "image registry: dockerhub"
+        PROXY_IMAGE="${IMAGE}"
+    fi
+    if [ "${tag_as_latest}" == "Y" ];  then
+        echo "tagging as latest and push image ${PROXY_IMAGE}"
+        docker tag ${IMAGE} ${PROXY_IMAGE}
+        docker push ${PROXY_IMAGE}
+    fi
+    if [ "${TAG}" != "" ];  then
+        echo "tagging as ${TAG} and push image  ${PROXY_IMAGE}"
+        docker tag ${IMAGE} ${PROXY_IMAGE}:${TAG}
+        docker push ${PROXY_IMAGE}:${TAG}
+    else
+        echo "TAG was not defined - image not retagged and pushed"
     fi
 else
     exit 1

--- a/tools/e2e-ycsb/Dockerfile
+++ b/tools/e2e-ycsb/Dockerfile
@@ -1,9 +1,14 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
-RUN apt update && \
-    apt install -y wget && \
-    apt install -y tar && \
-    apt install -y default-jre
+# Set environment variable to prevent interactive prompts
+ENV DEBIAN_FRONTEND=noninteractive
+# Set the timezone environment variable to UTC
+ENV TZ=UTC
+
+RUN apt-get update && \
+    apt-get install -y wget && \
+    apt-get install -y tar && \
+    apt-get install -y default-jre
 
 RUN echo "JAVA_HOME=$(java -XshowSettings:properties -version 2>&1 | sed '/^[[:space:]]*java\.home/!d;s/^[[:space:]]*java\.home[[:space:]]*=[[:space:]]*//')" >> /etc/environment
 RUN tail /etc/environment

--- a/tools/e2e-ycsb/README.md
+++ b/tools/e2e-ycsb/README.md
@@ -7,4 +7,4 @@ For more details check [YCSB](https://github.com/brianfrankcooper/YCSB)
 ## Building
 Run `./build.sh`
 
-This builds the image `mayadata/e2e-ycsb`
+This builds the image `openebs/e2e-ycsb`

--- a/tools/e2e-ycsb/build.sh
+++ b/tools/e2e-ycsb/build.sh
@@ -9,7 +9,7 @@
 # as long as we do not make breaking changes.
 
 set -e
-IMAGE="mayadata/e2e-ycsb"
+IMAGE="openebs/e2e-ycsb"
 TAG="v1.0.0"
 registry=""
 tag_as_latest=""
@@ -34,18 +34,23 @@ done
 
 if docker build -t ${IMAGE} . ; then
     if [ "${registry}" != "" ]; then
-        if [ "${tag_as_latest}" == "Y" ];  then
-            echo "tagging as latest and pushing image"
-            docker tag ${IMAGE} $registry/${IMAGE}
-            docker push $registry/${IMAGE}
-        fi
-        if [ "${TAG}" != "" ];  then
-            echo "tagging as ${TAG} and pushing image to ${registry}"
-            docker tag ${IMAGE} $registry/${IMAGE}:${TAG}
-            docker push $registry/${IMAGE}:${TAG}
-        else
-            echo "TAG was not defined - image not retagged and pushed"
-        fi
+        echo "image registry: ${registry}"
+        YCSB_IMAGE="${registry}/${IMAGE}"
+    else
+        echo "image registry: dockerhub"
+        YCSB_IMAGE="${IMAGE}"
+    fi
+    if [ "${tag_as_latest}" == "Y" ];  then
+        echo "tagging as latest and push image ${YCSB_IMAGE}"
+        docker tag ${IMAGE} ${YCSB_IMAGE}
+        docker push ${YCSB_IMAGE}
+    fi
+    if [ "${TAG}" != "" ];  then
+        echo "tagging as ${TAG} and push image  ${YCSB_IMAGE}"
+        docker tag ${IMAGE} ${YCSB_IMAGE}:${TAG}
+        docker push ${YCSB_IMAGE}:${TAG}
+    else
+        echo "TAG was not defined - image not retagged and pushed"
     fi
 else
     exit 1


### PR DESCRIPTION
- push tools images to openebs dockerub repo
- upgrade fio version to 3.37-e2e-0
- downgrade ycsb base ubuntu image to 20.04 from 22.04 because docker build was failing for docker version 20 with below error: 
    `#6 2.216 E: Problem executing scripts APT::Update::Post-Invoke 'rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true'
#6 2.216 E: Sub-process returned an error code`