### PR TITLE
fix: handle cleanup for deployment

### DIFF
--- a/common/k8stest/util_apps.go
+++ b/common/k8stest/util_apps.go
@@ -509,7 +509,7 @@ func (dfa *FioApp) Cleanup() error {
 				return fmt.Errorf("verify replicas before deleting PVC failed: %v", err)
 			}
 		}
-	} else {
+	} else if dfa.DeployName != "" {
 		err := DeleteDeployment(dfa.DeployName, common.NSDefault)
 		if err != nil {
 			return fmt.Errorf("failed to delete fio deployment %s, err: %v", dfa.DeployName, err)


### PR DESCRIPTION
Cleanup of Fio did not check if DeployName exists before deleting the deployment.
Added the check to delete the deployment only if it present