### PR TITLE
chore: add support to use readonly volumes

### DIFF
--- a/common/k8stest/util_apps.go
+++ b/common/k8stest/util_apps.go
@@ -80,6 +80,7 @@ type FioApp struct {
 	MaxSnapshots                        int
 	PoolHasTopologyKey                  string
 	PoolAffinityTopologyLabel           map[string]string
+	MountReadOnly                       bool
 	status                              dfaStatus
 }
 
@@ -212,6 +213,9 @@ func (dfa *FioApp) DeployFio(fioArgsSet common.FioAppArgsSet, podPrefix string) 
 
 		if dfa.AppNodeName != "" {
 			pod = pod.WithNodeName(dfa.AppNodeName)
+		}
+		if dfa.MountReadOnly {
+			pod = pod.WithMountReadOnly(true)
 		}
 		podObj, err := pod.Build()
 		if err != nil {

--- a/scripts/go-checks.sh
+++ b/scripts/go-checks.sh
@@ -33,18 +33,25 @@ fi
 
 if golangci-lint > /dev/null 2>&1 ; then
     cd "$GOSRCDIRAPPS" || exit 1
+    echo "## linting apps ##"
     if ! golangci-lint run -v --allow-parallel-runners ; then
         exitv=1
     fi
     cd "$GOSRCDIRCOMMON" || exit 1
+    echo ""
+    echo "## linting common ##"
     if ! golangci-lint run -v --allow-parallel-runners ; then
         exitv=1
     fi
     cd "$GOSRCDIRE2EAGENT" || exit 1
+    echo ""
+    echo "## linting e2e-agent ##"
     if ! golangci-lint run -v --allow-parallel-runners ; then
         exitv=1
     fi
     cd "$GOSRCDIRE2EPROXY" || exit 1
+    echo ""
+    echo "## linting e2e-proxy ##"
     if ! golangci-lint run -v --allow-parallel-runners ; then
         exitv=1
     fi


### PR DESCRIPTION
update PodBuilder to allow a global read only setting
for volumes.
This only applies to filesystem volumes.
Turning on read only for block volumes is considered
a failed pre-condition and the Build method will fail.
