### PR TITLE
chore: refine fioApp deployment support

### DIFF
--- a/common/e2e-fio.go
+++ b/common/e2e-fio.go
@@ -188,6 +188,7 @@ func (s *E2eFioPodLogSynopsis) String() string {
 type E2eFioPodOutputMonitor struct {
 	Completed bool
 	Synopsis  E2eFioPodLogSynopsis
+	PodName   string
 }
 
 type E2eFioArgsBuilder struct {

--- a/common/k8stest/util_testpods.go
+++ b/common/k8stest/util_testpods.go
@@ -444,6 +444,7 @@ func MonitorE2EFioPod(podName string, nameSpace string) (*common.E2eFioPodOutput
 		ScanFioPodLogs(pod, synopsis)
 		podOut.Completed = true
 	}(&podOut.Synopsis, *pod)
+	podOut.PodName = podName
 	return &podOut, podOut.Synopsis.Err
 }
 


### PR DESCRIPTION
fixes:
 - when waiting for deployment pod to be running break out of loop when no error and status is running
 - store deployment name in private status field after deployment
 - store pod name in pod output stream monitor object
 - make pod monitoring work in cases where the associated pod has changed (fio app deployment instances only)

additions:
 - add support function RefreshDeplymentFioPodName refreshes the associated pod name field for fio app instances which are deployments. This to allow testcases where the fio pod is deleted and started again.
- add support function WaitDeploymentRunning returns that deployment readiness fo fio app instances which are deployments.