### PR TITLE
helm install related fixes

### DIFF
--- a/common/e2e_config/e2e_config.go
+++ b/common/e2e_config/e2e_config.go
@@ -138,6 +138,7 @@ type ProductSpec struct {
 	LvmEnginePluginDriverName         string            `yaml:"lvmEnginePluginDriverName"`
 	UmbrellaOpenebsHelmChartName      string            `yaml:"umbrellaOpenebsHelmChartName"`
 	UseUmbrellaOpenEBSChart           bool              `yaml:"useUmbrellaOpenEBSChart" env:"e2e_use_umbrella_openebs_chart" env-default:"false"`
+	PrometheusNodeExporterServicePort int               `yaml:"prometheusNodeExporterServicePort" env-default:"10100"`
 }
 
 // E2EConfig is an application configuration structure

--- a/common/k8stest/util.go
+++ b/common/k8stest/util.go
@@ -1776,13 +1776,13 @@ func DsUpdateStrategy(dsName string, nameSpace string, rollingUpdate bool) error
 
 // SetNexusRebuildVerify sets or removes environment variable NEXUS_REBUILD_VERIFY for IO engine daemonset,
 // then deletes all the IO engine pods and waits for Mayastor to be ready and pools to be online
-func SetNexusRebuildVerify(on bool) error {
+func SetNexusRebuildVerify(on bool, daemonSetName string) error {
 	var err error
 	var updated bool
 	if on {
-		updated, err = DsSetContainerEnv("mayastor-io-engine", common.NSMayastor(), "io-engine", "NEXUS_REBUILD_VERIFY", "panic")
+		updated, err = DsSetContainerEnv(daemonSetName, common.NSMayastor(), "io-engine", "NEXUS_REBUILD_VERIFY", "panic")
 	} else {
-		updated, err = DsUnsetContainerEnv("mayastor-io-engine", common.NSMayastor(), "io-engine", "NEXUS_REBUILD_VERIFY")
+		updated, err = DsUnsetContainerEnv(daemonSetName, common.NSMayastor(), "io-engine", "NEXUS_REBUILD_VERIFY")
 	}
 	if err != nil {
 		return err

--- a/scripts/go-checks.sh
+++ b/scripts/go-checks.sh
@@ -55,6 +55,9 @@ if golangci-lint > /dev/null 2>&1 ; then
     if ! golangci-lint run -v --allow-parallel-runners ; then
         exitv=1
     fi
+
+    echo ""
+    echo "## linting src  ##"
     cd "$GOSRCDIRSRC" || exit 1
     if ! golangci-lint run -v --allow-parallel-runners ; then
         exitv=1


### PR DESCRIPTION
- In function SetNexusRebuildVerify,
    do not hard code name of the io-engine daemonset
    this will differ with helm chart used to install
    mayastor.
    Require caller to provide the name of the daemonset

- Add configuration item for monitoriing prometheus node
    exporter service.
    This is required to handle deployment on different platforms

-  emit marker when linting src path

