### PR TITLE
chore(ci): add ci smoke test for lvm and zfs and github action for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,7 @@
 name: K8s CI
-# on:
-#   pull_request:
-#     types: ['opened', 'edited', 'reopened', 'synchronize']
-# Since the on property is required, using the workflow_dispatch event, 
-# which allows you to manually trigger the workflow from the GitHub Actions interface.
 on:
-  workflow_dispatch:
+  pull_request:
+    types: ['opened', 'edited', 'reopened', 'synchronize']
 
 jobs:
   k8s-ci:
@@ -21,6 +17,17 @@ jobs:
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
           echo "NIX_PATH=$NIX_PATH" >> $GITHUB_ENV
           nix-shell shell.nix --run "echo"
+      - name: Go checks
+        run: |
+          nix-shell shell.nix --run "./scripts/go-checks.sh"
       - name: BootStrap k8s cluster
         run: |
-          nix-shell shell.nix --run "./scripts/k8s/deployer.sh start --mayastor --zfs --lvm"
+          nix-shell shell.nix --run "./scripts/k8s/deployer.sh start --workers 1 --zfs --lvm" 
+      - name: E2E smoke test
+        run: |
+          nix-shell shell.nix --run "./scripts/e2e-test.sh --testplan selfci"
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        timeout-minutes: 10
+        uses: mxschmitt/action-tmate@v3
+

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -36,7 +36,27 @@ jobs:
           nix-shell shell.nix --run "echo"
       - name: BootStrap k8s cluster
         run: |
-          nix-shell shell.nix --run "./scripts/k8s/deployer.sh start --zfs --lvm"
+          nix-shell shell.nix --run "./scripts/k8s/deployer.sh start --workers 1 --lvm"
       - name: Lvm e2e test
         run: |
           nix-shell shell.nix --run "./scripts/e2e-test.sh --testplan lvm"
+  zfs:
+    needs: ['lint']
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v11
+        with:
+          kvm: true
+      - uses: DeterminateSystems/magic-nix-cache-action@v6
+      - name: Pre-populate nix-shell
+        run: |
+          export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
+          echo "NIX_PATH=$NIX_PATH" >> $GITHUB_ENV
+          nix-shell shell.nix --run "echo"
+      - name: BootStrap k8s cluster
+        run: |
+          nix-shell shell.nix --run "./scripts/k8s/deployer.sh start --workers 1 --zfs"
+      - name: Lvm e2e test
+        run: |
+          nix-shell shell.nix --run "./scripts/e2e-test.sh --testplan zfs"

--- a/common/zfs/util.go
+++ b/common/zfs/util.go
@@ -92,9 +92,9 @@ func (zfsDevicePoolConfig *ZfsNodesDevicePoolConfig) ConfigureZfsNodesWithDevice
 			if err != nil {
 				return fmt.Errorf("failed to get node %s IP, error: %v", node, err)
 			}
-			_, zfsPoolErr := e2e_agent.ZfsCreatePool(*nodeIp, device.DiskPath, zfsDevicePoolConfig.PoolName)
-			if err != nil {
-				return fmt.Errorf("failed to create zfs pool on node %s, error: %v", node, zfsPoolErr)
+			out, zfsPoolErr := e2e_agent.ZfsCreatePool(*nodeIp, device.DiskPath, zfsDevicePoolConfig.PoolName)
+			if zfsPoolErr != nil {
+				return fmt.Errorf("failed to create zfs pool on node %s, error: %v, output: %s", node, zfsPoolErr, out)
 			}
 		}
 	}

--- a/src/tests/lvm/lvm_ci_smoke_test/lvm_ci_smoke_test.go
+++ b/src/tests/lvm/lvm_ci_smoke_test/lvm_ci_smoke_test.go
@@ -1,0 +1,71 @@
+package lvm_ci_smoke_test
+
+import (
+	"testing"
+
+	"github.com/openebs/openebs-e2e/common/e2e_ginkgo"
+	"github.com/openebs/openebs-e2e/common/lvm"
+	"github.com/openebs/openebs-e2e/src/tests/lvm/lvm_volume_provisioning"
+
+	"github.com/openebs/openebs-e2e/common"
+	"github.com/openebs/openebs-e2e/common/k8stest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var err error
+var nodeConfig lvm.LvmNodesDevicePvVgConfig
+var app k8stest.FioApplication
+
+func TestLvmCiSmokeTest(t *testing.T) {
+	// Initialise test and set class and file names for reports
+	e2e_ginkgo.InitTesting(t, "lvm_ci_smoke_test", "lvm_ci_smoke_test")
+}
+
+var _ = Describe("lvm_ci_smoke_test", func() {
+
+	BeforeEach(func() {
+		// Check ready to run
+		err := e2e_ginkgo.BeforeEachK8sCheck()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		// Check resource leakage.
+		after_err := e2e_ginkgo.AfterEachK8sCheck()
+		// cleanup k8s resources if exist
+		logf.Log.Info("cleanup k8s resources if exist")
+		err := app.Cleanup()
+		Expect(err).ToNot(HaveOccurred(), "failed to k8s resource")
+
+		Expect(after_err).ToNot(HaveOccurred())
+	})
+
+	It("lvm ci smoke test: should verify a volume can be created, used and deleted", func() {
+		app, err = lvm_volume_provisioning.VolumeProvisioningTest("lvm-ext4", common.Lvm, common.VolFileSystem, common.Ext4FsType, false, nodeConfig)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+})
+
+var _ = BeforeSuite(func() {
+	err := e2e_ginkgo.SetupTestEnv()
+	Expect(err).ToNot(HaveOccurred(), "failed to setup test environment in BeforeSuite : SetupTestEnv %v", err)
+
+	//setup nodes with lvm pv and vg
+	nodeConfig, err = lvm.SetupLvmNodes("lvmvg", 10737418240)
+	Expect(err).ToNot(HaveOccurred(), "failed to setup lvm pv and vg")
+})
+
+var _ = AfterSuite(func() {
+	// NB This only tears down the local structures for talking to the cluster,
+	// not the kubernetes cluster itself.	By("tearing down the test environment")
+	logf.Log.Info("remove node with device and vg", "node config", nodeConfig)
+	err := nodeConfig.RemoveConfiguredLvmNodesWithDeviceAndVg()
+	Expect(err).ToNot(HaveOccurred(), "failed to cleanup node with device")
+
+	err = k8stest.TeardownTestEnv()
+	Expect(err).ToNot(HaveOccurred(), "failed to tear down test environment in AfterSuite : TeardownTestEnv %v", err)
+})

--- a/src/tests/lvm/lvm_volume_provisioning/util.go
+++ b/src/tests/lvm/lvm_volume_provisioning/util.go
@@ -1,0 +1,55 @@
+package lvm_volume_provisioning
+
+import (
+	"github.com/openebs/openebs-e2e/common"
+	"github.com/openebs/openebs-e2e/common/k8stest"
+	"github.com/openebs/openebs-e2e/common/lvm"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var defFioCompletionTime = 240 // in seconds
+
+func VolumeProvisioningTest(decor string,
+	engine common.OpenEbsEngine,
+	volType common.VolumeType,
+	fstype common.FileSystemType,
+	volBindModeWait bool,
+	nodeConfig lvm.LvmNodesDevicePvVgConfig,
+) (k8stest.FioApplication, error) {
+
+	app := k8stest.FioApplication{
+		Decor:                   decor,
+		VolSizeMb:               2048,
+		OpenEbsEngine:           engine,
+		VolType:                 volType,
+		FsType:                  fstype,
+		Loops:                   1,
+		VolWaitForFirstConsumer: volBindModeWait,
+	}
+
+	// setup sc parameters
+	app.Lvm = k8stest.LvmOptions{
+		VolGroup:      nodeConfig.VgName,
+		Storage:       "lvm",
+		ThinProvision: common.No,
+	}
+
+	logf.Log.Info("create sc, pvc, fio pod")
+	err := app.DeployApplication()
+	if err != nil {
+		return app, err
+	}
+
+	logf.Log.Info("wait for fio pod to complete")
+	err = app.WaitComplete(defFioCompletionTime)
+	if err != nil {
+		return app, err
+	}
+	// remove app pod, pvc,sc
+	err = app.Cleanup()
+	if err != nil {
+		return app, err
+	}
+	return app, nil
+}

--- a/src/tests/zfs/zfs_ci_smoke_test/zfs_ci_smoke_test.go
+++ b/src/tests/zfs/zfs_ci_smoke_test/zfs_ci_smoke_test.go
@@ -1,0 +1,78 @@
+package zfs_ci_smoke_test
+
+import (
+	"testing"
+
+	"github.com/openebs/openebs-e2e/common"
+	"github.com/openebs/openebs-e2e/common/e2e_ginkgo"
+	"github.com/openebs/openebs-e2e/common/zfs"
+	"github.com/openebs/openebs-e2e/src/tests/zfs/zfs_volume_provisioning"
+
+	"github.com/openebs/openebs-e2e/common/k8stest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var nodeConfig zfs.ZfsNodesDevicePoolConfig
+var app k8stest.FioApplication
+var err error
+
+func TestZfsCiSmokeTest(t *testing.T) {
+	// Initialise test and set class and file names for reports
+	e2e_ginkgo.InitTesting(t, "zfs_ci_smoke_test", "zfs_ci_smoke_test")
+}
+
+var _ = Describe("zfs_ci_smoke_test", func() {
+
+	BeforeEach(func() {
+		// Check ready to run
+		err := e2e_ginkgo.BeforeEachK8sCheck()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		// cleanup k8s resources if exist
+		logf.Log.Info("cleanup k8s resources if exist")
+		err = app.Cleanup()
+		Expect(err).ToNot(HaveOccurred(), "failed to k8s resource")
+
+		// Check resource leakage.
+		after_err := e2e_ginkgo.AfterEachK8sCheck()
+
+		// cleanup k8s resources if exist
+		logf.Log.Info("cleanup k8s resources if exist")
+		err := app.Cleanup()
+		Expect(err).ToNot(HaveOccurred(), "failed to k8s resource")
+
+		Expect(after_err).ToNot(HaveOccurred())
+
+	})
+
+	It("zfs smoke test: should verify a volume can be created, used and deleted", func() {
+		app, err = zfs_volume_provisioning.VolumeProvisioningTest("ext4", common.Zfs, common.VolFileSystem, common.Ext4FsType, false, nodeConfig)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+})
+
+var _ = BeforeSuite(func() {
+	err = e2e_ginkgo.SetupTestEnv()
+	Expect(err).ToNot(HaveOccurred(), "failed to setup test environment in BeforeSuite : SetupTestEnv %v", err)
+
+	//setup nodes with zfs pool
+	nodeConfig, err = zfs.SetupZfsNodes("zfspv-pool", 10737418240)
+	Expect(err).ToNot(HaveOccurred(), "failed to setup zfs pool")
+
+})
+
+var _ = AfterSuite(func() {
+	logf.Log.Info("remove node with device and zpool", "node config", nodeConfig)
+	err = nodeConfig.RemoveConfiguredDeviceZfsPool()
+	Expect(err).ToNot(HaveOccurred(), "failed to cleanup node with device")
+	// NB This only tears down the local structures for talking to the cluster,
+	// not the kubernetes cluster itself.	By("tearing down the test environment")
+	err = k8stest.TeardownTestEnv()
+	Expect(err).ToNot(HaveOccurred(), "failed to tear down test environment in AfterSuite : TeardownTestEnv %v", err)
+})

--- a/testplans/selfci.yaml
+++ b/testplans/selfci.yaml
@@ -5,4 +5,5 @@ meta:
   include:
     - common
 testsuites:
-  - lvm_volume_provisioning
+  - zfs_ci_smoke_test
+  - lvm_ci_smoke_test


### PR DESCRIPTION
- Add smoke test for lvm and zfs engine
- Add workflow file to run selfci testplan profile on every PR changes
- Refactor existing lvm volume provisioning test so that test code can be shared between lvm smoke test
- Add zfs pipeline in scheduled e2e GitHub action
- Deploy cluster with one worker node only because it's not possible to create lvm vg and zfs pool  with same name on both worker nodes 