### PR TITLE
fix: add detached mode to tmate session

### DIFF
--- a/.github/workflows/debug-e2e-test.yml
+++ b/.github/workflows/debug-e2e-test.yml
@@ -37,7 +37,8 @@ jobs:
         run: |
           nix-shell shell.nix --run "./scripts/k8s/deployer.sh start --workers 1 --lvm"
       - name: Setup tmate session
-        # if: ${{ failure() }}
+        with:
+          detached: true
         timeout-minutes: 30
         uses: mxschmitt/action-tmate@v3
       - name: Lvm e2e test
@@ -61,7 +62,8 @@ jobs:
         run: |
           nix-shell shell.nix --run "./scripts/k8s/deployer.sh start --workers 1 --zfs"
       - name: Setup tmate session
-        # if: ${{ failure() }}
+        with:
+          detached: true
         timeout-minutes: 30
         uses: mxschmitt/action-tmate@v3
       - name: Zfs e2e test


### PR DESCRIPTION
By default, this Action starts a tmate session and waits for the session to be done (typically by way of a user connecting and exiting the shell after debugging). In detached mode, this Action will start the tmate session, print the connection details, and continue with the next step(s) of the workflow's job. At the end of the job, the Action will wait for the session to exit.

ref: https://github.com/marketplace/actions/debugging-with-tmate#detached-mode