### PR TITLE
fix: create file over mounted path for github action kind cluster

### DIFF
--- a/tools/e2e-agent/build.sh
+++ b/tools/e2e-agent/build.sh
@@ -9,7 +9,7 @@
 # as long as we do not make breaking changes.
 set -e
 IMAGE="openebs/e2e-agent"
-TAG="v3.0.2"
+TAG="v3.0.3"
 registry=""
 tag_as_latest=""
 

--- a/tools/e2e-agent/disk.go
+++ b/tools/e2e-agent/disk.go
@@ -41,7 +41,10 @@ func (disk *LoopDevice) createDiskImage() error {
 	if err != nil {
 		return fmt.Errorf("error truncating disk image. Error : %v", err)
 	}
-
+	err = f.Close()
+	if err != nil {
+		return fmt.Errorf("error closing disk image file %s. Error : %v", disk.ImageName, err)
+	}
 	return nil
 }
 

--- a/tools/e2e-agent/e2e-agent.yaml
+++ b/tools/e2e-agent/e2e-agent.yaml
@@ -50,7 +50,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: openebs/e2e-agent:v3.0.2
+          image: openebs/e2e-agent:v3.0.3
           imagePullPolicy: Always
           volumeMounts:
             - name: host-root


### PR DESCRIPTION
- Create disk image file at `/mnt` on host which will ` /host/host/mnt` in e2e-agent container because on github runner one device of 74G is mounted
- close the disk image file after truncate operation because `truncating an open file preserves the file but clears its contents, while deleting an open file removes its directory entry but keeps its contents accessible until fully closed. Deleting an open file removes its directory entry, but the file's contents remain accessible to the process that had it open. The file will show up as "(deleted)" in lsof output`

Tested here with the PR changes https://github.com/openebs/openebs-e2e/actions/runs/10934793318