### PR TITLE
chore: fix e2e_config to work with tools

### DIFF
--- a/common/e2e_config/e2e_config.go
+++ b/common/e2e_config/e2e_config.go
@@ -484,8 +484,10 @@ func GetConfig() E2EConfig {
 		var info os.FileInfo
 		e2eRootDir, haveE2ERootDir := os.LookupEnv("e2e_root_dir")
 		openebsE2eRootDir, haveOpenebsE2eRootDir := os.LookupEnv("openebs_e2e_root_dir")
-		if !haveOpenebsE2eRootDir {
-			panic("openebs e2e root environment variable not set")
+		if configContext == E2eTesting {
+			if !haveOpenebsE2eRootDir {
+				panic("openebs_e2e_root environment variable not set")
+			}
 		}
 
 		// Initialise the configuration

--- a/common/locations/util_locations.go
+++ b/common/locations/util_locations.go
@@ -10,26 +10,24 @@ import (
 	"github.com/openebs/openebs-e2e/common/e2e_config"
 )
 
-var openebsRootDir = e2e_config.GetConfig().OpenEbsE2eRootDir
-
 // GetE2EAgentPath return the path of e2e-agent install yaml file directory
 func GetE2EAgentPath() string {
-	return locationExists(openebsRootDir + "/tools/e2e-agent")
+	return locationExists(e2e_config.GetConfig().OpenEbsE2eRootDir + "/tools/e2e-agent")
 }
 
 // GetE2EProxyPath return the path of e2e-proxy install yaml file directory
 func GetE2EProxyPath() string {
-	return locationExists(openebsRootDir + "/tools/e2e-proxy")
+	return locationExists(e2e_config.GetConfig().OpenEbsE2eRootDir + "/tools/e2e-proxy")
 }
 
 // GetE2EServiceMonitorPath return the path of service monitor yaml file directory
 func GetE2EServiceMonitorPath() string {
-	return locationExists(openebsRootDir + "/configurations")
+	return locationExists(e2e_config.GetConfig().OpenEbsE2eRootDir + "/configurations")
 }
 
 // GetE2EScriptsPath return the path script directory
 func GetE2EScriptsPath() string {
-	return locationExists(openebsRootDir + "/scripts")
+	return locationExists(e2e_config.GetConfig().OpenEbsE2eRootDir + "/scripts")
 }
 
 func locationExists(path string) string {


### PR DESCRIPTION
- if configContext is not E2Etesting do not panic if environment variable openebs_e2e_root_dir is not defined.
- do not statically initialise using e2e_config