### PR TITLE
fix: don't fail aftereach if events collection fails

### DIFF
--- a/common/e2e_ginkgo/e2e_ginkgo.go
+++ b/common/e2e_ginkgo/e2e_ginkgo.go
@@ -181,6 +181,8 @@ func afterEachCheckResources(canGenSupportBundle bool) error {
 	eventMessages, err := event.GetAllEventMessagesSymbolic()
 	if err != nil {
 		log.Log.Info("failed to retrieve events", "error", err)
+		// log the error -but do not fail the test case
+		err = nil
 	} else {
 		yml, err := yaml.Marshal(eventMessages)
 		if err != nil {


### PR DESCRIPTION
post test case events collection failure is not
a test case failure