### PR TITLE
chore: add support for logs generation on testsuite failure

### DIFF
--- a/common/e2e_ginkgo/e2e_ginkgo.go
+++ b/common/e2e_ginkgo/e2e_ginkgo.go
@@ -3,6 +3,7 @@ package e2e_ginkgo
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/openebs/openebs-e2e/common"
@@ -242,4 +243,18 @@ func AfterEachCheck() error {
 
 func AfterEachK8sCheck() error {
 	return k8stest.ResourceK8sCheck()
+}
+
+func BeforeSuiteFailed() {
+	testSpec := ginkgo.CurrentSpecReport()
+	leaf := testSpec.LeafNodeLocation.FileName
+	leaflets := strings.Split(leaf, "/")
+	if len(leaflets) > 1 {
+		logsPath, err := common.GetTestSuiteLogsPath(leaflets[len(leaflets)-2])
+		if err == nil {
+			k8stest.GenerateSupportBundle(logsPath)
+		} else {
+			log.Log.Info("test suite logs path was not set", "location", leaf)
+		}
+	}
 }

--- a/common/vars.go
+++ b/common/vars.go
@@ -100,3 +100,19 @@ func ResetTestCaseLogsPath() {
 	currentTestCase = ""
 	testcaseLogsPath = ""
 }
+
+// GetTestSuiteLogsPath get the path to the logs directory for the current test suite
+func GetTestSuiteLogsPath(testsuite string) (string, error) {
+	if len(testsuite) > 1 {
+		logRoot, ok := os.LookupEnv("e2etestlogdir")
+		if !ok {
+			logRoot = "/tmp/e2e/logs"
+		}
+		t0 := time.Now().UTC()
+		ts := fmt.Sprintf("%v%02d%02d%v%v%v", t0.Year(), t0.Month(), t0.Day(), t0.Hour(), t0.Minute(), t0.Second())
+		tsLogsPath := fmt.Sprintf("%s/%s/%s", logRoot, strings.Map(SanitizePathname, testsuite), ts)
+		return tsLogsPath, nil
+	} else {
+		return "", fmt.Errorf("zero length testsuite name")
+	}
+}


### PR DESCRIPTION
Add support functions that can be invoked in BeforeSuite functions to generate logs on failure.