### PR TITLE
chore: fio-app: FS vols: support size in MiB

### DIFF
--- a/common/e2e-fio.go
+++ b/common/e2e-fio.go
@@ -134,6 +134,7 @@ const (
 	FioFsAllocDefault      FioFsAllocation = iota
 	FioFsAllocLessByBlocks FioFsAllocation = iota
 	FioFsAllocPercentage   FioFsAllocation = iota
+	FioFsAllocMiB          FioFsAllocation = iota
 )
 
 type fioTarget struct {
@@ -463,6 +464,10 @@ func (e *E2eFioArgsBuilder) Build() ([]string, error) {
 			case FioFsAllocPercentage:
 				cmdLine = append(cmdLine, []string{
 					"makefile", tgt.device, tgt.fsFile, "availblockspercent", fmt.Sprintf("%d", tgt.fsAllocUnit), ";",
+				}...)
+			case FioFsAllocMiB:
+				cmdLine = append(cmdLine, []string{
+					"makefile", tgt.device, tgt.fsFile, "MiB", fmt.Sprintf("%d", tgt.fsAllocUnit), ";",
 				}...)
 			}
 		}

--- a/common/e2e_config/e2e_config.go
+++ b/common/e2e_config/e2e_config.go
@@ -198,7 +198,7 @@ type E2EConfig struct {
 	ImagePullPolicy              string `yaml:"imagePullPolicy" env-default:"IfNotPresent" env:"e2e_image_pull_policy"`
 	InstallLoki                  bool   `yaml:"installLoki" env-default:"true" env:"install_loki"`
 	LokiStatefulsetOnControlNode bool   `yaml:"lokiOnControlNode" env-default:"true" env:"loki_on_control_node"`
-	E2eFioImage                  string `yaml:"e2eFioImage" env-default:"openebs/e2e-fio:v3.37-e2e-0" env:"e2e_fio_image"`
+	E2eFioImage                  string `yaml:"e2eFioImage" env-default:"openebs/e2e-fio:v3.38-e2e-0" env:"e2e_fio_image"`
 	SetSafeMountAlways           bool   `yaml:"setSafeMountAlways" env-default:"false" env:"safe_mount_always"`
 	// This is an advisory setting for individual tests
 	// If set to true - typically during test development - tests with multiple 'It' clauses should defer asserts till after

--- a/common/k8stest/util_apps.go
+++ b/common/k8stest/util_apps.go
@@ -52,7 +52,7 @@ type FioApp struct {
 	// 0 -> default (lessby N blocks) unless FsMiB is non-zero
 	// > 0 < 100 percentage of available blocks used
 	FsPercent uint
-	// non-zero and FsPercent is 0 -> test file size in MiB
+	// FS test file size in MiB - only effective if FsPercent == 0
 	FsMiB                               uint
 	ReplicaCount                        int
 	Runtime                             uint

--- a/common/k8stest/util_apps.go
+++ b/common/k8stest/util_apps.go
@@ -49,9 +49,11 @@ type FioApp struct {
 	VolType    common.VolumeType
 	FsType     common.FileSystemType
 	// FsPercent -> controls size of file allocated on FS
-	// 0 -> default (lessby N blocks)
+	// 0 -> default (lessby N blocks) unless FsMiB is non-zero
 	// > 0 < 100 percentage of available blocks used
-	FsPercent                           uint
+	FsPercent uint
+	// non-zero and FsPercent is 0 -> test file size in MiB
+	FsMiB                               uint
 	ReplicaCount                        int
 	Runtime                             uint
 	Loops                               int
@@ -141,7 +143,11 @@ func (dfa *FioApp) DeployFio(fioArgsSet common.FioAppArgsSet, podPrefix string) 
 	if dfa.status.fioTargets == nil {
 		if dfa.VolType == common.VolFileSystem {
 			if dfa.FsPercent == 0 {
-				efab = efab.WithDefaultFile()
+				if dfa.FsMiB == 0 {
+					efab = efab.WithDefaultFile()
+				} else {
+					efab = efab.WithDefaultFileExt(common.FioFsAllocMiB, dfa.FsMiB)
+				}
 			} else {
 				if dfa.FsPercent > 100 {
 					return fmt.Errorf("invalid FsPercent value, valid range is 1 - 100")

--- a/common/k8stest/util_fio_app.go
+++ b/common/k8stest/util_fio_app.go
@@ -34,9 +34,11 @@ type FioApplication struct {
 	FsType        common.FileSystemType
 	OpenEbsEngine common.OpenEbsEngine
 	// FsPercent -> controls size of file allocated on FS
-	// 0 -> default (lessby N blocks)
+	// 0 -> default (lessby N blocks) unless FsMiB is non-zero.
 	// > 0 < 100 percentage of available blocks used
-	FsPercent                      uint
+	FsPercent uint
+	// non-zero and FsPercent is 0 -> test file size in MiB
+	FsMiB                          uint
 	Runtime                        uint
 	Loops                          int
 	AddFioArgs                     []string
@@ -132,7 +134,11 @@ func (dfa *FioApplication) DeployFio(fioArgsSet common.FioAppArgsSet, podPrefix 
 	if dfa.status.fioTargets == nil {
 		if dfa.VolType == common.VolFileSystem {
 			if dfa.FsPercent == 0 {
-				efab = efab.WithDefaultFile()
+				if dfa.FsMiB == 0 {
+					efab = efab.WithDefaultFile()
+				} else {
+					efab = efab.WithDefaultFileExt(common.FioFsAllocMiB, dfa.FsMiB)
+				}
 			} else {
 				if dfa.FsPercent > 100 {
 					return fmt.Errorf("invalid FsPercent value, valid range is 1 - 100")

--- a/src/tests/hostpath/hostpath_data_integrity/hostpath_data_integrity_test.go
+++ b/src/tests/hostpath/hostpath_data_integrity/hostpath_data_integrity_test.go
@@ -24,6 +24,7 @@ func dataIntegrityTestTest(decor string, fstype common.FileSystemType) {
 	app := k8stest.FioApplication{
 		Decor:                   decor,
 		VolSizeMb:               1024,
+		FsMiB:                   768,
 		OpenEbsEngine:           common.Hostpath,
 		VolType:                 common.VolFileSystem,
 		FsType:                  fstype,


### PR DESCRIPTION
openebs/e2e-fio v3.38-e2e-0 supports specifying
fio test file size in MiB

Add that support to fio apps.
If FsPercent == 0 and FsMiB is non-zero
then the fio test file created will be
FsMiB MibiBytes in size.