### PR TITLE
chore: mayastor: update configuration

### DIFF
--- a/common/e2e_config/e2e_config.go
+++ b/common/e2e_config/e2e_config.go
@@ -166,6 +166,8 @@ type E2EConfig struct {
 		MayastorNamespace string `yaml:"mayastorNamespace" env-default:"mayastor"`
 		// Some deployments use a different namespace
 		FilteredMayastorPodCheck int `yaml:"filteredMayastorPodCheck" env-default:"0"`
+		// data plane interface
+		IOEngineTargetNvmfIface string `yaml:"ioengineTargetNvmfIface" env-default:"" env:"e2e_ioengine_target_nvmf_iface"`
 	} `yaml:"platform"`
 	Product ProductSpec `yaml:"product"`
 


### PR DESCRIPTION
Add configuration item for
mayastor io engine target nvmf interface selection

Configurable by environment variable e2e_ioengine_target_nvmf_iface or platform configuration file