### PR TITLE
fix: Update the disk pool api version for upgrade related tests

### DIFF
--- a/configurations/product/mayastor_config.yaml
+++ b/configurations/product/mayastor_config.yaml
@@ -103,7 +103,7 @@ product:
     statsService: "mayastor-obs-callhome-stats"
     upgradePodLabelValue: "upgrade"
     diskPoolAPIVersionMap:
-      develop: "openebs.io/v1beta2"
+      develop: "openebs.io/v1beta3"
       2.0.0: "openebs.io/v1alpha1"
       2.0.1: "openebs.io/v1alpha1"
       2.1.0: "openebs.io/v1alpha1"


### PR DESCRIPTION
The DiskPool API version has been updated to v1beta3 on the develop branch. As a result of this change, upgrade-related jobs are currently failing. This PR updates the API version of disk pool and will fixes those failures. 
