### PR TITLE
fix: add mayastor plugin name

### DIFF
--- a/common/e2e_config/e2e_config.go
+++ b/common/e2e_config/e2e_config.go
@@ -78,6 +78,7 @@ type ProductSpec struct {
 	LoggingLabel                      string            `yaml:"loggingLabel" env-default:"openebs.io/logging"`
 	LogLevel                          string            `yaml:"logLevel" env-default:"debug"`
 	LokiStatefulset                   string            `yaml:"lokiStatefulset" env-default:"mayastor-loki"`
+	MayastorPluginName                string            `yaml:"mayastorPluginName"`
 	MetricsPollingInterval            string            `yaml:"metricsPollingInterval" env-default:"30s"`
 	MongoAuthDatabase                 string            `yaml:"mongoAuthDatabase" env-default:"test"`
 	MongoAuthPassword                 string            `yaml:"mongoAuthPassword" env-default:"admin123"`

--- a/configurations/product/mayastor_config.yaml
+++ b/configurations/product/mayastor_config.yaml
@@ -62,6 +62,7 @@ product:
     loggingLabel: "openebs.io/logging"
     logLevel: "debug"
     lokiStatefulset: "mayastor-loki"
+    mayastorPluginName: "kubectl-mayastor"
     metricsPollingInterval: "30s"
     mongoAuthDatabase: "test"
     mongoAuthPassword: "admin123"


### PR DESCRIPTION
This PR adds MayastorPluginName config parameter which will be fixed as kubectl-mayastor