### PR TITLE
fix: ignore minio and loki sts while verifying mayastor ready check

### DIFF
--- a/common/e2e_config/e2e_config.go
+++ b/common/e2e_config/e2e_config.go
@@ -35,6 +35,8 @@ type ProductSpec struct {
 	ControlPlaneCoreAgent             string            `yaml:"controlPlaneCoreAgent" env-default:"agent-core"`
 	ControlPlaneCsiController         string            `yaml:"controlPlaneCsiController" env-default:"csi-controller"`
 	ControlPlaneEtcd                  string            `yaml:"controlPlaneEtcd" env-default:"mayastor-etcd"`
+	ControlPlaneLoki                  string            `yaml:"controlPlaneLoki" env-default:"mayastor-loki"`
+	ControlPlaneMinio                 string            `yaml:"controlPlaneMinio" env-default:"mayastor-minio"`
 	ControlPlanePoolOperator          string            `yaml:"controlPlanePoolOperator" env-default:"msp-operator"`
 	ControlPlaneRestServer            string            `yaml:"controlPlaneRestServer" env-default:"rest"`
 	ControlPlaneLocalpvProvisioner    string            `yaml:"controlPlaneLocalpvProvisioner" env-default:"mayastor-localpv-provisioner"`

--- a/common/k8stest/util.go
+++ b/common/k8stest/util.go
@@ -1363,6 +1363,14 @@ func readyCheck(namespace string, verbose bool) (bool, error) {
 					logf.Log.Info("Skipping etcd statefulset ready check", "name", sts.Name)
 					continue
 				}
+				if e2e_config.GetConfig().Product.ControlPlaneLoki == sts.Name {
+					logf.Log.Info("Skipping Loki statefulset ready check", "name", sts.Name)
+					continue
+				}
+				if e2e_config.GetConfig().Product.ControlPlaneMinio == sts.Name {
+					logf.Log.Info("Skipping Minio statefulset ready check", "name", sts.Name)
+					continue
+				}
 				ready := sts.Status.Replicas == sts.Status.ReadyReplicas && sts.Status.ReadyReplicas == sts.Status.CurrentReplicas && sts.Status.ReadyReplicas != 0
 				if verbose {
 					logf.Log.Info("StatefulSet",
@@ -1586,39 +1594,6 @@ func GetDeploymentReplicaCount(deploymentName string, namespace string) (int32, 
 			err)
 	}
 	return *deployment.Spec.Replicas, err
-}
-
-func SetPromtailTolerations(tolerations []coreV1.Toleration, promtailDsName string, namespace string) error {
-	dsAPI := gTestEnv.KubeInt.AppsV1().DaemonSets
-	var err error
-
-	// this is to cater for a race condition, occasionally seen,
-	// when the deployment is changed between Get and Update
-	for attempts := 0; attempts < 10; attempts++ {
-		ds, err := dsAPI(namespace).Get(context.TODO(), promtailDsName, metaV1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to get daemonset, name: %s, namespace: %s, error: %v",
-				promtailDsName,
-				namespace,
-				err)
-		}
-		ds.Spec.Template.Spec.Tolerations = tolerations
-
-		_, err = dsAPI(namespace).Update(context.TODO(), ds, metaV1.UpdateOptions{})
-		if err == nil {
-			break
-		}
-		logf.Log.Info("Re-trying update attempt due to error", "error", err)
-		time.Sleep(1 * time.Second)
-	}
-
-	if err != nil {
-		return fmt.Errorf("failed to add node toleration to daemonset, name: %s, namespace: %s, error: %v",
-			promtailDsName,
-			namespace,
-			err)
-	}
-	return nil
 }
 
 // VerifyIoEnginePodDeletionFromNode verify io engine pod removal from node

--- a/common/k8stest/util_testpods.go
+++ b/common/k8stest/util_testpods.go
@@ -304,7 +304,11 @@ func CheckForTestPods() (bool, error) {
 // isPodHealthCheckCandidate is a filter function for health check on pod,
 func isPodHealthCheckCandidate(podName string, namespace string) bool {
 	if namespace == common.NSMayastor() {
-		return !strings.HasPrefix(podName, "mayastor-etcd")
+		if strings.HasPrefix(podName, e2e_config.GetConfig().Product.ControlPlaneEtcd) ||
+			strings.HasPrefix(podName, e2e_config.GetConfig().Product.ControlPlaneLoki) ||
+			strings.HasPrefix(podName, e2e_config.GetConfig().Product.ControlPlaneMinio) {
+			return false
+		}
 	}
 	return true
 }

--- a/common/mayastor/partial_rebuild/partial_rebuild.go
+++ b/common/mayastor/partial_rebuild/partial_rebuild.go
@@ -228,7 +228,9 @@ func RescheduleCpAndShutdownNode(cpNode string, faultNode string) (string, error
 	}
 
 	// verify mayastor ready
-	excludeList := []string{e2e_config.GetConfig().Product.ControlPlaneEtcd}
+	excludeList := []string{e2e_config.GetConfig().Product.ControlPlaneEtcd,
+		e2e_config.GetConfig().Product.ControlPlaneMinio,
+		e2e_config.GetConfig().Product.ControlPlaneLoki}
 	ready, err := k8stest.MayastorReadyWithException(2, 360, excludeList)
 	if err != nil {
 		return shutdownNode, err

--- a/configurations/product/mayastor_config.yaml
+++ b/configurations/product/mayastor_config.yaml
@@ -5,6 +5,8 @@ product:
     controlPlaneCoreAgent: "mayastor-agent-core"
     controlPlaneCsiController: "mayastor-csi-controller"
     controlPlaneEtcd: "mayastor-etcd"
+    controlPlaneLoki: "mayastor-loki"
+    controlPlaneMinio: "mayastor-minio"
     controlPlanePoolOperator: "mayastor-operator-diskpool"
     controlPlaneRestServer: "mayastor-api-rest"
     controlPlaneLocalpvProvisioner: "mayastor-localpv-provisioner"


### PR DESCRIPTION
- ignore minio and loki sts while verifying mayastor ready check
- ignore minio and loki pod while verifying pod ready check in mayastor namespace
- remove SetPromtailTolerations function as it's not needed now 