### PR TITLE
chore: add resource quota support to ZFS storage class builder

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -60,6 +60,7 @@ const ScZfsThinProvision = "thinProvision"
 const ScZfsDeDup = "dedup"
 const ScZfsPoolName = "poolname"
 const ScZfsVolBlockSize = "volblocksize"
+const ScZfsQuotaType = "quotatype"
 
 //  These variables match the settings used in fsx pod definition
 

--- a/common/k8stest/util_fio_app.go
+++ b/common/k8stest/util_fio_app.go
@@ -80,6 +80,7 @@ type ZfsOptions struct {
 	ThinProvision     common.YesNoVal
 	VolBlockSize      string
 	Shared            common.YesNoVal
+	QuotaType         string
 }
 
 type HostPathOptions struct {
@@ -380,6 +381,10 @@ func (dfa *FioApplication) CreateSc() error {
 		}
 		if dfa.Zfs.DedUp.String() != "" {
 			scBuilder = scBuilder.WithZfsDeDUp(dfa.Zfs.DedUp.String())
+		}
+		// Add quota type support - only set if not empty
+		if dfa.Zfs.QuotaType != "" {
+			scBuilder = scBuilder.WithZfsQuotaType(dfa.Zfs.QuotaType)
 		}
 
 	} else if dfa.OpenEbsEngine == common.Hostpath {

--- a/common/k8stest/util_storageclass.go
+++ b/common/k8stest/util_storageclass.go
@@ -471,3 +471,15 @@ func (b *ScBuilder) WithZfsPoolName(value string) *ScBuilder {
 	b.sc.object.Parameters[string(common.ScZfsPoolName)] = value
 	return b
 }
+
+// WithZfsQuotaType sets the quotatype parameter of storageclass to given argument.
+func (b *ScBuilder) WithZfsQuotaType(value string) *ScBuilder {
+	if value == "" {
+		return b // Don't set parameter if value is empty
+	}
+	if b.sc.object.Parameters == nil {
+		b.sc.object.Parameters = map[string]string{}
+	}
+	b.sc.object.Parameters[string(common.ScZfsQuotaType)] = value
+	return b
+}


### PR DESCRIPTION
Added support for the quota type in the ZFS storage class builder and introduced the corresponding parameter in the FIO Application utility. If a value is provided in the FIO application, the resource quota will be set accordingly; if no value is passed, the quota type will remain unset. 