### PR TITLE
chore: add support to verify local engine volume cr as part of volume creation and deletion

### DIFF
--- a/common/k8stest/util.go
+++ b/common/k8stest/util.go
@@ -1282,7 +1282,7 @@ func CreateScVolumeAndFio(prefix string, replicaCount int, volSizeMb int, nodeNa
 		return scFioVolumeName, fmt.Errorf("failed to create storage class %s, error: %v", scFioVolumeName.ScName, err)
 	}
 	scFioVolumeName.VolName = fmt.Sprintf("vol-%s", scFioVolumeName.ScName)
-	uid, err := MakePVC(volSizeMb, scFioVolumeName.VolName, scFioVolumeName.ScName, volType, common.NSDefault, false, false)
+	uid, err := MakePVC(volSizeMb, scFioVolumeName.VolName, scFioVolumeName.ScName, volType, common.NSDefault, common.Mayastor, false)
 	if err != nil {
 		return scFioVolumeName, fmt.Errorf("failed to create pvc %s, errorr: %v", scFioVolumeName.VolName, err)
 	}
@@ -1316,7 +1316,7 @@ func DeleteScVolumeAndFio(scFioVolumeName ScFioVolumeName) error {
 		return fmt.Errorf("failed to delete fio pod %s, error: %v", scFioVolumeName.FioPodName, err)
 	}
 	// Delete the volume
-	err = RemovePVC(scFioVolumeName.VolName, scFioVolumeName.ScName, common.NSDefault, false)
+	err = RemovePVC(scFioVolumeName.VolName, scFioVolumeName.ScName, common.NSDefault, common.Mayastor)
 	if err != nil {
 		return fmt.Errorf("failed to delete volume %s, error: %v", scFioVolumeName.VolName, err)
 	}

--- a/common/k8stest/util_apps.go
+++ b/common/k8stest/util_apps.go
@@ -517,7 +517,7 @@ func (dfa *FioApp) CreateVolume() error {
 			return err
 		}
 	} else {
-		dfa.status.volUuid, err = MakePVC(dfa.VolSizeMb, dfa.status.volName, dfa.status.scName, dfa.VolType, common.NSDefault, false, false)
+		dfa.status.volUuid, err = MakePVC(dfa.VolSizeMb, dfa.status.volName, dfa.status.scName, dfa.VolType, common.NSDefault, common.Mayastor, false)
 		dfa.status.createdPVC = dfa.status.volUuid != ""
 		if err != nil {
 			return fmt.Errorf("failed to create pvc %s, %v", dfa.status.volName, err)
@@ -591,7 +591,7 @@ func (dfa *FioApp) Cleanup() error {
 	}
 	// Only delete PVC and storage class if they were created by this instance
 	if dfa.status.createdPVC {
-		err = RemovePVC(dfa.status.volName, dfa.status.scName, common.NSDefault, false)
+		err = RemovePVC(dfa.status.volName, dfa.status.scName, common.NSDefault, common.Mayastor)
 		if err == nil && !dfa.KeepStorageClass {
 			// Only delete storage class if KeepStorageClass is false (default behavior)
 			err = RmStorageClass(dfa.status.scName)
@@ -609,7 +609,7 @@ func (dfa *FioApp) Cleanup() error {
 func (dfa *FioApp) ForcedCleanup() {
 	_ = DeletePod(dfa.status.podName, common.NSDefault)
 	dfa.status.podName = ""
-	_ = RemovePVC(dfa.status.volName, dfa.status.scName, common.NSDefault, false)
+	_ = RemovePVC(dfa.status.volName, dfa.status.scName, common.NSDefault, common.Mayastor)
 	dfa.status.createdVolume = false
 	dfa.status.createdPVC = false
 	_ = RmStorageClass(dfa.status.scName)

--- a/common/k8stest/util_busybox.go
+++ b/common/k8stest/util_busybox.go
@@ -69,7 +69,7 @@ func CleanUpBusyboxResources(pods []string, pvcName string) error {
 		if err != nil {
 			return fmt.Errorf("failed to get pvc %s err %v", pvcName, err)
 		}
-		err = RemovePVC(pvcName, *pvc.Spec.StorageClassName, common.NSDefault, true)
+		err = RemovePVC(pvcName, *pvc.Spec.StorageClassName, common.NSDefault, common.None)
 		if err != nil {
 			return fmt.Errorf("failed to delete pvc %s err %v", pvcName, err)
 		}

--- a/common/k8stest/util_fio_app.go
+++ b/common/k8stest/util_fio_app.go
@@ -284,13 +284,9 @@ func (dfa *FioApplication) CreateVolume() error {
 	if err != nil {
 		return fmt.Errorf("failed to create sc %s, %v", dfa.status.scName, err)
 	}
-	var localEngine bool
-	if dfa.OpenEbsEngine != common.Mayastor {
-		localEngine = true
-	}
 
 	// Create the volume
-	_, err = MakePVC(dfa.VolSizeMb, dfa.status.pvcName, dfa.status.scName, dfa.VolType, common.NSDefault, localEngine, dfa.SkipPvcVerificationAfterCreate)
+	_, err = MakePVC(dfa.VolSizeMb, dfa.status.pvcName, dfa.status.scName, dfa.VolType, common.NSDefault, dfa.OpenEbsEngine, dfa.SkipPvcVerificationAfterCreate)
 
 	if err != nil {
 		return fmt.Errorf("failed to create pvc %s, %v", dfa.status.pvcName, err)
@@ -436,13 +432,9 @@ func (dfa *FioApplication) Cleanup() error {
 		dfa.status.fioPodName = ""
 
 	}
-	var localEngine bool
-	if dfa.OpenEbsEngine != common.Mayastor {
-		localEngine = true
-	}
 	// Only delete PVC and storage class if they were created by this instance
 	if dfa.status.createdPVC {
-		err = RemovePVC(dfa.status.pvcName, dfa.status.scName, common.NSDefault, localEngine)
+		err = RemovePVC(dfa.status.pvcName, dfa.status.scName, common.NSDefault, dfa.OpenEbsEngine)
 		if err == nil && !dfa.KeepStorageClass {
 			dfa.status.createdPVC = false
 			// Only delete storage class if KeepStorageClass is false (default behavior)
@@ -461,7 +453,7 @@ func (dfa *FioApplication) Cleanup() error {
 func (dfa *FioApplication) ForcedCleanup() {
 	_ = DeletePod(dfa.status.fioPodName, common.NSDefault)
 	dfa.status.fioPodName = ""
-	_ = RemovePVC(dfa.status.pvcName, dfa.status.scName, common.NSDefault, false)
+	_ = RemovePVC(dfa.status.pvcName, dfa.status.scName, common.NSDefault, dfa.OpenEbsEngine)
 	dfa.status.createdPVC = false
 	_ = RmStorageClass(dfa.status.scName)
 	dfa.status.scName = ""

--- a/common/k8stest/util_fiostsapp.go
+++ b/common/k8stest/util_fiostsapp.go
@@ -186,7 +186,7 @@ func (dfa *FioStsApp) Cleanup(replicaCount int) error {
 			// for e.g `testpvc-pod-0`
 			// where testpvc is claim name and pod is statefulset name and pod-0 is pod name
 			volName := dfa.VolName + "-" + dfa.StsName + "-" + strconv.Itoa(i)
-			err = RemovePVC(volName, dfa.ScName, common.NSDefault, false)
+			err = RemovePVC(volName, dfa.ScName, common.NSDefault, common.Mayastor)
 			if err != nil {
 				return fmt.Errorf("failed to remove pvc %s", volName)
 			}

--- a/common/k8stest/util_pvc.go
+++ b/common/k8stest/util_pvc.go
@@ -339,7 +339,7 @@ func PVCCreateAndFailCordon(
 	}
 	// check that a volume hasn't been created
 	msvs, msverr := controlplane.ListMsvs()
-	_ = RemovePVC(volName, scName, common.NSDefault, false)
+	_ = RemovePVC(volName, scName, common.NSDefault, common.Mayastor)
 	if msverr != nil {
 		return fmt.Errorf("failed to list msvs, error: %s", msverr.Error())
 	}
@@ -670,7 +670,7 @@ func TryMkOversizedPVC(volSizeMb int, volName string, scName string, volType com
 		eventList, listerr := GetEvents(nameSpace, options)
 		if listerr != nil {
 			err = fmt.Errorf("failed to get namespace events, pvc: %s, namespace:  %s, error: %v", volName, nameSpace, listerr)
-			_ = RemovePVC(volName, scName, nameSpace, false)
+			_ = RemovePVC(volName, scName, nameSpace, common.Mayastor)
 			return foundOversizeError, err
 		}
 		for _, event := range eventList.Items {
@@ -1160,7 +1160,7 @@ func GetPvCapacity(pvName string) (*resource.Quantity, error) {
 //  1. The PVC status transitions to bound,
 //  2. The associated PV is created and its status transitions bound
 //  3. The associated maaystor volume is created and has a State "healthy" if engine is mayastor
-func MakePVC(volSizeMb int, volName string, scName string, volType common.VolumeType, nameSpace string, local bool, skipVolumeVerification bool) (string, error) {
+func MakePVC(volSizeMb int, volName string, scName string, volType common.VolumeType, nameSpace string, engine common.OpenEbsEngine, skipVolumeVerification bool) (string, error) {
 	volSizeMbStr := fmt.Sprintf("%dMi", volSizeMb)
 	logf.Log.Info("Creating", "volume", volName, "storageClass", scName, "volume type", volType, "size", volSizeMbStr)
 
@@ -1221,11 +1221,15 @@ func MakePVC(volSizeMb int, volName string, scName string, volType common.Volume
 		if err != nil {
 			return string(pvc.ObjectMeta.UID), err
 		}
-		if !local {
+		if engine == common.Mayastor {
 			uuid, err = VerifyMayastorVolumeProvision(volName, nameSpace)
 			if err != nil {
 				return string(pvc.ObjectMeta.UID), err
 			}
+		} else if engine == common.Zfs {
+			logf.Log.Info("NOT IMPLEMENTED: Verify volume verification for zfs engine")
+		} else if engine == common.Lvm {
+			logf.Log.Info("NOT IMPLEMENTED: Verify volume verification for lvm engine")
 		}
 		logf.Log.Info("Created", "volume", volName, "uuid", pvc.ObjectMeta.UID, "storageClass", scName, "volume type", volType, "size", volSizeMbStr, "elapsed time", time.Since(t0))
 		return uuid, nil
@@ -1238,7 +1242,7 @@ func MakePVC(volSizeMb int, volName string, scName string, volType common.Volume
 //  1. The PVC is deleted
 //  2. The associated PV is deleted
 //  3. The associated mayastor volume is deleted if engine is mayastor
-func RemovePVC(volName string, scName string, nameSpace string, local bool) error {
+func RemovePVC(volName string, scName string, nameSpace string, engine common.OpenEbsEngine) error {
 	const timoSleepSecs = 1
 	logf.Log.Info("Removing volume", "volume", volName, "storageClass", scName)
 	var isDeleted bool
@@ -1300,7 +1304,7 @@ func RemovePVC(volName string, scName string, nameSpace string, local bool) erro
 	}
 
 	// if it's replicated engine(mayastor), verify mayastor volume deletion
-	if !local {
+	if engine == common.Mayastor {
 		// Wait for the mayastor to be deleted.
 		for ix := 0; ix < defTimeoutSecs/timoSleepSecs; ix++ {
 			isDeleted = IsMsvDeleted(string(pvc.ObjectMeta.UID))
@@ -1312,6 +1316,10 @@ func RemovePVC(volName string, scName string, nameSpace string, local bool) erro
 		if !isDeleted {
 			return fmt.Errorf("mayastor volume not deleted, msv: %s", pvc.ObjectMeta.UID)
 		}
+	} else if engine == common.Zfs {
+		logf.Log.Info("NOT IMPLEMENTED: RemovePVC for zfs engine")
+	} else if engine == common.Lvm {
+		logf.Log.Info("NOT IMPLEMENTED: RemovePVC for lvm engine")
 	}
 	return nil
 }

--- a/common/mayastor/disk_pool_operator/disk_pool_operator.go
+++ b/common/mayastor/disk_pool_operator/disk_pool_operator.go
@@ -165,7 +165,7 @@ func (tc *TestCase) DeployApp() error {
 		return fmt.Errorf("failed to create storage class %s %v", tc.ScName, err)
 	}
 	// Create the volume
-	tc.Uid, err = k8stest.MakePVC(tc.VolSizeMb, tc.VolName, tc.ScName, tc.VolType, common.NSDefault, false, false)
+	tc.Uid, err = k8stest.MakePVC(tc.VolSizeMb, tc.VolName, tc.ScName, tc.VolType, common.NSDefault, common.Mayastor, false)
 	if err != nil {
 		return fmt.Errorf("failed to create pvc %s, %v", tc.VolName, err)
 	}
@@ -217,7 +217,7 @@ func (tc *TestCase) Cleanup() error {
 	// delete pod and volume
 	err = k8stest.DeletePod(tc.PodName, common.NSDefault)
 	if err == nil {
-		err = k8stest.RemovePVC(tc.VolName, tc.ScName, common.NSDefault, false)
+		err = k8stest.RemovePVC(tc.VolName, tc.ScName, common.NSDefault, common.Mayastor)
 		if err == nil {
 			err = k8stest.RmStorageClass(tc.ScName)
 		}

--- a/common/mayastor/nexus_ha/nexus_ha.go
+++ b/common/mayastor/nexus_ha/nexus_ha.go
@@ -376,7 +376,7 @@ func (c *NexusHa) CreateScAndVolume(prefix string, replicas int, volSizeMb int) 
 		return fmt.Errorf("failed to create storage class %s", scName)
 	}
 	volName := fmt.Sprintf("vol-%s", scName)
-	uid, err := k8stest.MakePVC(volSizeMb, volName, scName, common.VolFileSystem, common.NSDefault, false, false)
+	uid, err := k8stest.MakePVC(volSizeMb, volName, scName, common.VolFileSystem, common.NSDefault, common.Mayastor, false)
 	if err != nil {
 		return fmt.Errorf("failed to create pvc %s", volName)
 	}
@@ -395,7 +395,7 @@ func (c *NexusHa) DeleteScAndVolume() error {
 	logf.Log.Info("pvc", "pvName ->", pvc.Spec.VolumeName, "volume->", c.volName)
 
 	//Delete the volume
-	err = k8stest.RemovePVC(c.volName, c.scName, common.NSDefault, false)
+	err = k8stest.RemovePVC(c.volName, c.scName, common.NSDefault, common.Mayastor)
 	if err != nil {
 		logf.Log.Error(err, "failed to delete", "pvc", c.volName)
 		return err

--- a/common/mayastor/thin_provisioning/thin_provisioning.go
+++ b/common/mayastor/thin_provisioning/thin_provisioning.go
@@ -80,7 +80,7 @@ func randomInt(min, max int) int {
 func CreateVolume(scName, volBaseName string, volSizeMb int) (string, string, error) {
 	// Create the volume
 	volName := strings.ToLower(fmt.Sprintf("%s-vol-%d-%s-%s-%s", volBaseName, common.DefaultReplicaCount(), common.ShareProtoNvmf, common.VolRawBlock, randomString(5)))
-	uid, err := k8stest.MakePVC(volSizeMb, volName, scName, common.VolRawBlock, common.NSDefault, false, false)
+	uid, err := k8stest.MakePVC(volSizeMb, volName, scName, common.VolRawBlock, common.NSDefault, common.Mayastor, false)
 	if err != nil {
 		return uid, volName, err
 	}
@@ -190,7 +190,7 @@ func CreateAndRunRunningFio(sizeMiB int, volName string) *coreV1.Pod {
 
 func CleanUp(scName string, volNames []string) error {
 	for _, name := range volNames {
-		err := k8stest.RemovePVC(name, scName, common.NSDefault, false)
+		err := k8stest.RemovePVC(name, scName, common.NSDefault, common.Mayastor)
 		if err != nil {
 			return err
 		}

--- a/common/types.go
+++ b/common/types.go
@@ -181,6 +181,7 @@ const (
 	Hostpath OpenEbsEngine = iota
 	Zfs      OpenEbsEngine = iota
 	Mayastor OpenEbsEngine = iota
+	None     OpenEbsEngine = iota
 )
 
 func (Engine OpenEbsEngine) String() string {
@@ -193,6 +194,8 @@ func (Engine OpenEbsEngine) String() string {
 		return "zfs"
 	case Mayastor:
 		return "mayastor"
+	case None:
+		return "none"
 	default:
 		return ""
 	}


### PR DESCRIPTION
- Add framework support to verify lvm and zfs volume verification while creation and deletion of volume
- Actual implementation for lvm and zfs volume will be taken in another PR