### PR TITLE
fix: changes to verify image tag version for openebs upgrade

### DIFF
--- a/common/controlplane/v1/upgrade.go
+++ b/common/controlplane/v1/upgrade.go
@@ -182,6 +182,7 @@ func (cp CPv1) GetUpgradeStatus() (string, error) {
 	for _, line := range strings.Split(string(output), "\n") {
 		if strings.Contains(line, "Upgrade Status") {
 			parts := strings.Split(line, ":")
+			logf.Log.Info("Output", "Upgrade Status", strings.TrimSpace(parts[len(parts)-1]))
 			return strings.TrimSpace(parts[len(parts)-1]), nil
 		}
 	}
@@ -203,7 +204,7 @@ func (cp CPv1) GetToUpgradeVersion() (string, error) {
 		if strings.Contains(line, "Upgrade To") {
 			fields := strings.Fields(line)
 			if len(fields) > 0 {
-				return fields[len(fields)-1], nil
+				return strings.TrimSpace(fields[len(fields)-1]), nil
 			}
 		}
 	}

--- a/common/e2e_config/e2e_config.go
+++ b/common/e2e_config/e2e_config.go
@@ -160,6 +160,7 @@ type ProductSpec struct {
 	LokiIngesterChunkRetainPeriodTime string            `yaml:"lokiIngesterChunkRetainPeriodTime"`
 	LokiIngesterMaxChunkAgeTime       string            `yaml:"lokiIngesterMaxChunkAgeTime"`
 	OciRegistryUrl                    string            `yaml:"ociRegistryUrl" env-default:""`
+	OpenebsToMayaVersionMap           map[string]string `yaml:"openebsToMayaVersionMap"`
 }
 
 // E2EConfig is an application configuration structure

--- a/common/mayastor/upgrade/upgrade.go
+++ b/common/mayastor/upgrade/upgrade.go
@@ -50,8 +50,8 @@ var (
 	UpgradingControlPlane        string = " Upgrading " + cases.Title(language.Und).String(e2e_config.GetConfig().Product.ProductName) + " control-plane"
 	UpgradingDataPlane           string = " Upgrading " + cases.Title(language.Und).String(e2e_config.GetConfig().Product.ProductName) + " data-plane"
 	UpgradingDataPlaneForOpenEBS string = " Upgrading data-plane"
-	UpgradeCompleted             string = " Successfully upgraded " + cases.Title(language.Und).String(e2e_config.GetConfig().Product.ProductName)
-	UpgradeSuccessful            string = " Upgrade successful"
+	UpgradeCompleted             string = "Successfully upgraded " + cases.Title(language.Und).String(e2e_config.GetConfig().Product.ProductName)
+	UpgradeSuccessful            string = "Upgrade successful"
 )
 
 var MSDeployment = []string{
@@ -80,6 +80,9 @@ type TestApp struct {
 
 func AreContainerImagesUpgraded(podList *coreV1.PodList, toUpgradeImageTag, dockerImageOrgName string) (bool, error) {
 	var localPVContainerName = e2e_config.GetConfig().Product.LocalPVContainerName
+	mayastorVersion := e2e_config.GetConfig().Product.OpenebsToMayaVersionMap[toUpgradeImageTag]
+	openebsPlugin := e2e_config.GetConfig().Product.KubectlOpenebsPluginName
+	binPath := mcpV1.GetPluginPath()
 	for _, pod := range podList.Items {
 		for _, container := range pod.Spec.Containers {
 			if strings.Contains(container.Image, dockerImageOrgName) {
@@ -88,12 +91,19 @@ func AreContainerImagesUpgraded(podList *coreV1.PodList, toUpgradeImageTag, dock
 					return false, fmt.Errorf("image didn't split successfully in name and tag parts")
 				}
 				logf.Log.Info("Container images are", "container name: ", container.Name, " container image: ", container.Image)
-
+				lastField := imageTag[len(imageTag)-1]
 				if container.Name != localPVContainerName {
-					if !strings.Contains(imageTag[len(imageTag)-1], toUpgradeImageTag) {
+
+					logf.Log.Info("Container Information", "container name: ", container.Name, " imageTag: ", lastField, "OpenebsToMayaVersionMap: ", mayastorVersion)
+					// Check if the OpenebsToMayaVersionMap is empty if plugin is openebs plugin
+					// Else check if the image tag or mayastor version matches with the toUpgradeImageTag
+					if filepath.Base(binPath) == openebsPlugin && mayastorVersion == "" {
+						logf.Log.Info("OpenebsToMayaVersionMap is empty for the toUpgradeImageTag: ", toUpgradeImageTag)
+						return false, nil
+					} else if !(strings.Contains(lastField, toUpgradeImageTag) || strings.Contains(lastField, mayastorVersion)) {
 						return false, nil
 					}
-				} else if !strings.Contains(imageTag[len(imageTag)-1], common.ToLocalpvProvisionerImage) {
+				} else if !strings.Contains(lastField, common.ToLocalpvProvisionerImage) {
 					return false, nil
 				}
 			}

--- a/configurations/product/mayastor_config.yaml
+++ b/configurations/product/mayastor_config.yaml
@@ -140,6 +140,10 @@ product:
       4.3.0: "openebs.io/v1beta3"
       4.3.1: "openebs.io/v1beta3"
       4.3.2: "openebs.io/v1beta3"
+    openebsToMayaVersionMap:
+      4.3.0: "2.9.0"
+      4.3.1: "2.9.1"
+      4.3.2: "2.9.1"
     chartName: "mayastor"
     chartVersion: "0.0.0-main"
     localPVContainerName: "mayastor-localpv-provisioner"


### PR DESCRIPTION
Below changes are done as part of this commit
1. Add log info in GetUpgradeStatus function
2. Return space trimmed string value in GetToUpgradeVersion function
3. Add OpenebsToMayaVersionMap to ProductSpec
4. Add logic to verify image tag versions after openebs upgrade to
   AreContainerImagesUpgraded function
5. Add openebsToMayaVersionMap map to mayastor_config.yaml

