### PR TITLE
fix: ignore thin pool deletion error if thin pool LV already cleaned up automatically

### DIFF
--- a/src/tests/lvm/common/util_resize.go
+++ b/src/tests/lvm/common/util_resize.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/openebs/openebs-e2e/common/e2e_agent"
@@ -19,6 +20,8 @@ var ResizeApp k8stest.FioApplication
 var ResizeApp2 k8stest.FioApplication
 var defFioCompletionTime = 240 // in seconds
 var ThinPoolNode string
+
+const ThinPoolNotFound = "Failed to find logical volume"
 
 func LvmVolumeResizeTest(decor string, engine common.OpenEbsEngine, vgName string, volType common.VolumeType, fstype common.FileSystemType, volBindModeWait bool, thinProvisioned common.YesNoVal) {
 
@@ -147,7 +150,11 @@ func LvmVolumeResizeTest(decor string, engine common.OpenEbsEngine, vgName strin
 
 	if thinProvisioned == common.Yes {
 		out, err := e2e_agent.LvmLvRemoveThinPool(ThinPoolNode, vgName)
-		Expect(err).To(BeNil(), "failed to remove lv thin pool on node %s with vg %s, output: %s", node, vgName, out)
+		if err != nil && strings.Contains(out, ThinPoolNotFound) {
+			logf.Log.Info("ERROR: failed to remove thin pool LV as it was not found", "node:", ThinPoolNode, "vg name:", "lvmvg", "output:", out)
+		} else if err != nil {
+			Expect(err).ToNot(HaveOccurred(), "failed to remove lv thin pool on node %s with vg %s, output: %s", ThinPoolNode, "lvmvg", out)
+		}
 		ThinPoolNode = ""
 	}
 }

--- a/src/tests/lvm/lvm_thin_volume_resize/lvm_thin_volume_resize_test.go
+++ b/src/tests/lvm/lvm_thin_volume_resize/lvm_thin_volume_resize_test.go
@@ -1,6 +1,7 @@
 package lvm_thin_volume_resize
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/openebs/openebs-e2e/common"
@@ -52,7 +53,11 @@ var _ = Describe("lvm_thin_volume_resize", func() {
 		Expect(err).ToNot(HaveOccurred(), "failed to k8s resource")
 		if volumeResize.ThinPoolNode != "" {
 			out, err := e2e_agent.LvmLvRemoveThinPool(volumeResize.ThinPoolNode, "lvmvg")
-			Expect(err).To(BeNil(), "failed to remove lv thin pool on node %s with vg %s, output: %s", volumeResize.ThinPoolNode, "lvmvg", out)
+			if err != nil && strings.Contains(out, volumeResize.ThinPoolNotFound) {
+				logf.Log.Info("ERROR: failed to remove thin pool LV as it was not found", "node:", volumeResize.ThinPoolNode, "vg name:", "lvmvg", "output:", out)
+			} else if err != nil {
+				Expect(err).ToNot(HaveOccurred(), "failed to remove lv thin pool on node %s with vg %s, output: %s", volumeResize.ThinPoolNode, "lvmvg", out)
+			}
 		}
 
 		Expect(after_err).ToNot(HaveOccurred())


### PR DESCRIPTION
This is needed because thinpool capacity reclaimed after last thin lv deleted by openebs lvm driver after this [PR](https://github.com/openebs/lvm-localpv/pull/412). Earlier user have to manually delete thin pool LV which is not the case now.