### PR TITLE
feat: add common utils function for offline pool deletion feature

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -104,3 +104,8 @@ const (
 	SleepTime                        = 3    // in seconds
 	ToLocalpvProvisionerImage        = "4.4.0"
 )
+
+// Annotations for delete options for offline pools
+const (
+	DeleteOptsAnnotation = "openebs.io/delete-opts"
+)

--- a/common/controlplane/controlplane.go
+++ b/common/controlplane/controlplane.go
@@ -123,8 +123,11 @@ type ControlPlaneInterface interface {
 	ListZFSVolumes() ([]common.ZFSVolume, error)
 	GetZFSVolumeStatus(name string) (string, error)
 
-    // Pool expansion abstraction
-    ExpandPoolViaPlugin(poolName string) error
+	// Pool expansion abstraction
+	ExpandPoolViaPlugin(poolName string) error
+
+	// Pool deletion abstraction
+	DeleteOfflinePoolViaPlugin(poolName string, constraints ...common.OfflinePoolDelete) error
 }
 
 var ifc ControlPlaneInterface
@@ -512,5 +515,9 @@ func GetZFSVolumeStatus(name string) (string, error) {
 
 // GrowPoolViaPlugin uses kubectl mayastor plugin to grow the pool
 func ExpandPoolViaPlugin(poolName string) error {
-    return getControlPlane().ExpandPoolViaPlugin(poolName)
+	return getControlPlane().ExpandPoolViaPlugin(poolName)
+}
+
+func DeleteOfflinePoolViaPlugin(poolName string, flags ...common.OfflinePoolDelete) error {
+	return getControlPlane().DeleteOfflinePoolViaPlugin(poolName, flags...)
 }

--- a/common/controlplane/v1-rest-api/msp_cp.go
+++ b/common/controlplane/v1-rest-api/msp_cp.go
@@ -66,3 +66,9 @@ func (cp CPv1RestApi) ListMsPools() ([]common.MayastorPool, error) {
 func (cp CPv1RestApi) ExpandPoolViaPlugin(poolName string) error {
 	panic(fmt.Errorf("pool expand via plugin is not implemented in REST API mode, use kubectl plugin mode"))
 }
+
+// DeleteOfflinePoolViaPlugin deletes the offline pool via control plane plugin
+// Note: This method is not implemented in REST API mode, returns an error
+func (cp CPv1RestApi) DeleteOfflinePoolViaPlugin(poolName string, flags ...common.OfflinePoolDelete) error {
+	panic(fmt.Errorf("pool delete via REST API is not implemented yet"))
+}

--- a/common/controlplane/v1/msp_cp.go
+++ b/common/controlplane/v1/msp_cp.go
@@ -11,8 +11,6 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-
-
 type MayastorCpPool struct {
 	Id    string   `json:"id"`
 	Spec  mspSpec  `json:"spec"`
@@ -25,7 +23,7 @@ type mspSpec struct {
 	Labels      map[string]string `json:"labels"`
 	Node        string            `json:"node"`
 	Status      string            `json:"status"`
-	CordonDrain *CordonDrainSpec `json:"cordonDrain,omitempty"`
+	CordonDrain *CordonDrainSpec  `json:"cordonDrain,omitempty"`
 }
 
 // CordonDrainSpec represents the cordon drain specification structure
@@ -54,9 +52,9 @@ type mspState struct {
 	Status    string   `json:"status"`
 	Used      uint64   `json:"used"`
 	Committed uint64   `json:"committed"`
-    // Additional fields exposed by plugin JSON
-    DiskCapacityBytes  uint64 `json:"diskCapacity"`
-    MaxExpandableBytes uint64 `json:"maxExpandableSize"`
+	// Additional fields exposed by plugin JSON
+	DiskCapacityBytes  uint64 `json:"diskCapacity"`
+	MaxExpandableBytes uint64 `json:"maxExpandableSize"`
 }
 
 func (cp CPv1) CreatePoolOnInstall() bool {
@@ -88,11 +86,11 @@ func GetMayastorCpPool(name string) (*MayastorCpPool, error) {
 
 // Expose disk capacity and max expandable size in bytes for tests
 func (cp CPv1) GetPoolDiskCapacityAndMaxExpandable(name string) (uint64, uint64, error) {
-    p, err := GetMayastorCpPool(name)
-    if err != nil {
-        return 0, 0, err
-    }
-    return p.State.DiskCapacityBytes, p.State.MaxExpandableBytes, nil
+	p, err := GetMayastorCpPool(name)
+	if err != nil {
+		return 0, 0, err
+	}
+	return p.State.DiskCapacityBytes, p.State.MaxExpandableBytes, nil
 }
 
 func ListMayastorCpPools() ([]MayastorCpPool, error) {
@@ -173,9 +171,9 @@ func (cp CPv1) CordonPool(poolID string, constraints ...common.PoolCordonConstra
 		}
 	}
 	logf.Log.Info("Executing cordon pool command", "pool", poolID, "constraints", constraintStrings)
-	
+
 	args := []string{"-n", common.NSMayastor(), "cordon", "pool"}
-	
+
 	// Add constraint flags if specified
 	for _, constraint := range constraints {
 		switch constraint {
@@ -189,23 +187,23 @@ func (cp CPv1) CordonPool(poolID string, constraints ...common.PoolCordonConstra
 			args = append(args, "--import")
 		}
 	}
-	
+
 	args = append(args, poolID)
-	
+
 	// Log the actual command being executed
 	logf.Log.Info("Executing command", "command", "mayastor", "args", args)
-	
+
 	cmd := GetMayastorPluginCmd(args...)
-	
+
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out
-	
+
 	err := cmd.Run()
 	if err != nil {
 		return fmt.Errorf("plugin failed to cordon pool %s with constraints %v, error %v, output: %s", poolID, constraintStrings, err, out.String())
 	}
-	
+
 	logf.Log.Info("Successfully cordoned pool", "pool", poolID, "constraints", constraintStrings, "output", out.String())
 	return nil
 }
@@ -219,9 +217,9 @@ func (cp CPv1) UnCordonPool(poolID string, constraints ...common.PoolCordonConst
 		}
 	}
 	logf.Log.Info("Executing uncordon pool command", "pool", poolID, "constraints", constraintStrings)
-	
+
 	args := []string{"-n", common.NSMayastor(), "uncordon", "pool"}
-	
+
 	// Add constraint flags if specified
 	for _, constraint := range constraints {
 		switch constraint {
@@ -235,23 +233,23 @@ func (cp CPv1) UnCordonPool(poolID string, constraints ...common.PoolCordonConst
 			args = append(args, "--import")
 		}
 	}
-	
+
 	args = append(args, poolID)
-	
+
 	// Log the actual command being executed
 	logf.Log.Info("Executing command", "command", "mayastor", "args", args)
-	
+
 	cmd := GetMayastorPluginCmd(args...)
-	
+
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out
-	
+
 	err := cmd.Run()
 	if err != nil {
 		return fmt.Errorf("plugin failed to uncordon pool %s with constraints %v, error %v, output: %s", poolID, constraintStrings, err, out.String())
 	}
-	
+
 	logf.Log.Info("Successfully uncordoned pool", "pool", poolID, "constraints", constraintStrings, "output", out.String())
 	return nil
 }
@@ -259,40 +257,40 @@ func (cp CPv1) UnCordonPool(poolID string, constraints ...common.PoolCordonConst
 // GetPoolCordonStatus gets the current cordon status of a pool
 func (cp CPv1) GetPoolCordonStatus(poolID string) (*PoolCordonStatus, error) {
 	logf.Log.Info("Getting cordon status for pool", "pool", poolID)
-	
+
 	args := []string{"-n", common.NSMayastor(), "-ojson", "get", "pool", poolID}
-	
+
 	// Log the actual command being executed
 	logf.Log.Info("Executing command", "command", "mayastor", "args", args)
-	
+
 	cmd := GetMayastorPluginCmd(args...)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out
-	
+
 	err := cmd.Run()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cordon status for pool %s, error %v", poolID, err)
 	}
-	
+
 	outputString := out.String()
 	var poolInfo MayastorCpPool
 	err = json.Unmarshal([]byte(outputString), &poolInfo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal command output for pool %s, error %v", outputString, err)
 	}
-	
+
 	status := &PoolCordonStatus{
-		PoolID: poolID,
+		PoolID:     poolID,
 		IsCordoned: poolInfo.Spec.CordonDrain != nil && poolInfo.Spec.CordonDrain.Cordoned != nil && poolInfo.Spec.CordonDrain.Cordoned.IsCordoned(),
 	}
-	
+
 	if poolInfo.Spec.CordonDrain != nil && poolInfo.Spec.CordonDrain.Cordoned != nil {
 		// Parse the cordon constraints from the YAML structure
 		// The cordonDrain field contains the constraint information
 		status.Constraints = parseCordonConstraints(poolInfo.Spec.CordonDrain.Cordoned)
 	}
-	
+
 	return status, nil
 }
 
@@ -309,10 +307,10 @@ func parseCordonConstraints(cordoned *PoolCordonedState) []string {
 	if cordoned == nil {
 		return []string{}
 	}
-	
+
 	// Parse cordonDrain field for constraints
 	constraints := []string{}
-	
+
 	if cordoned.Replicas {
 		constraints = append(constraints, "replicas")
 	}
@@ -325,30 +323,69 @@ func parseCordonConstraints(cordoned *PoolCordonedState) []string {
 	if cordoned.Import {
 		constraints = append(constraints, "import")
 	}
-	
+
 	return constraints
 }
 
 // ExpandPoolViaPlugin uses kubectl mayastor plugin to expand the pool
 func (cp CPv1) ExpandPoolViaPlugin(poolName string) error {
-    logf.Log.Info("Expanding pool via plugin", "pool", poolName)
-    
-    args := []string{"-n", common.NSMayastor(), "expand", "pool", poolName}
-    
-    // Log the actual command being executed
-    logf.Log.Info("Executing command", "command", "kubectl mayastor", "args", args)
-    
-    cmd := GetMayastorPluginCmd(args...)
-    
-    var out bytes.Buffer
-    cmd.Stdout = &out
-    cmd.Stderr = &out
-    
-    err := cmd.Run()
-    if err != nil {
-        return fmt.Errorf("plugin failed to expand pool %s, error %v, output: %s", poolName, err, out.String())
-    }
-    
-    logf.Log.Info("Successfully expanded pool via plugin", "pool", poolName, "output", out.String())
-    return nil
+	logf.Log.Info("Expanding pool via plugin", "pool", poolName)
+
+	args := []string{"-n", common.NSMayastor(), "expand", "pool", poolName}
+
+	// Log the actual command being executed
+	logf.Log.Info("Executing command", "command", "kubectl mayastor", "args", args)
+
+	cmd := GetMayastorPluginCmd(args...)
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("plugin failed to expand pool %s, error %v, output: %s", poolName, err, out.String())
+	}
+
+	logf.Log.Info("Successfully expanded pool via plugin", "pool", poolName, "output", out.String())
+	return nil
+}
+
+// Common Utilities for Offline Pool Deletion Tests
+
+// DeletePoolViaPlugin uses kubectl mayastor plugin to delete the pool
+func (cp CPv1) DeleteOfflinePoolViaPlugin(poolName string, flags ...common.OfflinePoolDelete) error {
+	logf.Log.Info("Deleting pool via plugin", "pool", poolName)
+	args := []string{"-n", common.NSMayastor(), "delete", "pool", poolName}
+
+	// Add constraint flags if specified
+	for _, flag := range flags {
+		switch flag {
+		case common.PurgePool:
+			args = append(args, "--purge")
+		case common.ConfirmPoolDelete:
+			args = append(args, "--confirm")
+		case common.ConfirmDataLoss:
+			args = append(args, "--confirm-data-loss")
+		case common.ConfirmSnapshotLoss:
+			args = append(args, "--confirm-snapshot-loss")
+		}
+	}
+
+	// Log the actual command being executed
+	logf.Log.Info("Executing command", "command", "kubectl mayastor", "args", args)
+
+	cmd := GetMayastorPluginCmd(args...)
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("plugin failed to delete pool %s, error %v, output: %s", poolName, err, out.String())
+	}
+
+	logf.Log.Info("Successfully deleted pool via plugin", "pool", poolName, "output", out.String())
+	return nil
 }

--- a/common/custom_resources/types/types.go
+++ b/common/custom_resources/types/types.go
@@ -51,4 +51,5 @@ type DiskPoolFunctions interface {
 	CreateMsPoolWithEncryptionAndMaxSize(poolName string, node string, disks []string, encryptionSecretName string, maxSize string, clusterSize string) (DiskPool, error)
 	AnnotatePoolForExpansion(poolName string) error
 	VerifyPoolCapacityAndMaxExpansion(poolName string, expectedCapacity uint64, expectedMaxExpansion string) error
+	AnnotateOfflinePoolForDelete(poolName string, opts ...string) error
 }

--- a/common/custom_resources/util.go
+++ b/common/custom_resources/util.go
@@ -274,6 +274,16 @@ func ExpandPoolViaPluginCP(poolName string) error {
 	return controlplane.ExpandPoolViaPlugin(poolName)
 }
 
+// DeleteOfflinePoolViaPluginCp deletes the offline pool via control plane plugin
+func DeleteOfflinePoolViaPluginCp(poolName string, flags ...common.OfflinePoolDelete) error {
+	return controlplane.DeleteOfflinePoolViaPlugin(poolName, flags...)
+}
+
+// AnnotateOfflinePoolForDelete annotates the offline pool for delete
+func AnnotateOfflinePoolForDelete(poolName string, opts ...string) error {
+	return getDspFuncs().AnnotateOfflinePoolForDelete(poolName)
+}
+
 // CheckAllMsPoolsAreOnline checks if all mayastor pools are online
 func CheckAllMsPoolsAreOnline() error {
 	initialise()

--- a/common/custom_resources/v1alpha1Ext/dsp.go
+++ b/common/custom_resources/v1alpha1Ext/dsp.go
@@ -309,3 +309,7 @@ func (ifc v1alpha1ExtIfc) AnnotatePoolForExpansion(poolName string) error {
 func (ifc v1alpha1ExtIfc) VerifyPoolCapacityAndMaxExpansion(poolName string, expectedCapacity uint64, expectedMaxExpansion string) error {
 	panic(fmt.Errorf("pool capacity and max expansion verification not supported in v1alpha1Ext"))
 }
+
+func (ifc v1alpha1ExtIfc) AnnotateOfflinePoolForDelete(poolName string, opts ...string) error {
+	panic(fmt.Errorf("annotate offline pool for delete not supported in v1alpha1Ext"))
+}

--- a/common/custom_resources/v1beta1/dsp.go
+++ b/common/custom_resources/v1beta1/dsp.go
@@ -274,3 +274,7 @@ func (ifc v1beta1Ifc) AnnotatePoolForExpansion(poolName string) error {
 func (ifc v1beta1Ifc) VerifyPoolCapacityAndMaxExpansion(poolName string, expectedCapacity uint64, expectedMaxExpansion string) error {
 	panic(fmt.Errorf("pool capacity and max expansion verification not supported in v1beta1"))
 }
+
+func (ifc v1beta1Ifc) AnnotateOfflinePoolForDelete(poolName string, opts ...string) error {
+	panic(fmt.Errorf("annotate offline pool for delete not supported in v1beta1"))
+}

--- a/common/custom_resources/v1beta2/dsp.go
+++ b/common/custom_resources/v1beta2/dsp.go
@@ -293,3 +293,7 @@ func (ifc v1beta2Ifc) AnnotatePoolForExpansion(poolName string) error {
 func (ifc v1beta2Ifc) VerifyPoolCapacityAndMaxExpansion(poolName string, expectedCapacity uint64, expectedMaxExpansion string) error {
 	panic(fmt.Errorf("pool capacity and max expansion verification not supported in v1beta2"))
 }
+
+func (ifc v1beta2Ifc) AnnotateOfflinePoolForDelete(poolName string, opts ...string) error {
+	panic(fmt.Errorf("annotate offline pool for delete not supported in v1beta2"))
+}

--- a/common/custom_resources/v1beta3/dsp.go
+++ b/common/custom_resources/v1beta3/dsp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/openebs/openebs-e2e/common"
 
@@ -484,4 +485,60 @@ func (ifc v1beta3Ifc) VerifyPoolCapacityAndMaxExpansion(poolName string, expecte
 		"capacity", actualCapacity,
 		"maxExpansion", actualMaxExpansion)
 	return nil
+}
+
+// AnnotateOfflinePoolForDelete adds the openebs.io/delete-opts annotation for offline pool deletion
+// with specified options passed as strings
+func (ifc v1beta3Ifc) AnnotateOfflinePoolForDelete(poolName string, opts ...string) error {
+	res, err := poolClientSet.DiskPools().Get(context.TODO(), poolName, metaV1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get pool %s: %v", poolName, err)
+	}
+	if res == nil {
+		return fmt.Errorf("pool %s not found", poolName)
+	}
+
+	// Build the annotation value based on provided options
+	annotationValue := ifc.buildDeleteOptsAnnotation(opts...)
+
+	if annotationValue == "" {
+		return fmt.Errorf("at least one delete option must be specified")
+	}
+
+	// Add or update the delete-opts annotation for offline pool
+	if res.Annotations == nil {
+		res.Annotations = make(map[string]string)
+	}
+	res.Annotations[common.DeleteOptsAnnotation] = annotationValue
+
+	_, err = poolClientSet.DiskPools().Update(context.TODO(), res, metaV1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to annotate offline pool %s for deletion: %v", poolName, err)
+	}
+
+	logf.Log.Info("Successfully annotated offline pool for deletion", "pool", poolName, "options", annotationValue)
+	return nil
+}
+
+// buildDeleteOptsAnnotation constructs the YAML-formatted annotation value from option strings
+func (ifc v1beta3Ifc) buildDeleteOptsAnnotation(opts ...string) string {
+	var parts []string
+	validOpts := map[string]string{
+		"purge":                 "purge: true",
+		"confirm":               "confirm: true",
+		"confirm_data_loss":     "confirm_data_loss: true",
+		"confirm_snapshot_loss": "confirm_snapshot_loss: true",
+	}
+
+	for _, opt := range opts {
+		if value, exists := validOpts[opt]; exists {
+			parts = append(parts, value)
+		}
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+
+	return strings.Join(parts, "\n")
 }

--- a/common/mayastor/offline_pool_delete/offline_pool_delete.go
+++ b/common/mayastor/offline_pool_delete/offline_pool_delete.go
@@ -1,0 +1,29 @@
+package offline_pool_delete
+
+import (
+	"github.com/openebs/openebs-e2e/common"
+	"github.com/openebs/openebs-e2e/common/controlplane"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// FixME : error messages related to offline pool delete
+
+var (
+	PoolOnlineState                = "purge not allowed"
+	DeleteWithoutPurgeFlag         = "purge flag is required to delete pool, pool is not in online state"
+	DeleteOfflinePoolWithoutCordon = "cannot delete pool that is offline without cordoning it first"
+	DeleteOfflinePoolWithReplica   = "pool has replicas, cannot delete without confirm flag"
+	DeleteOfflinePoolWithSnapshots = "pool has snapshots, cannot delete without confirm snapshot loss flag"
+	DeleteOfflinePoolWithData      = "pool has data, cannot delete without confirm data loss flag" // last healthy replica is scheduled on this pool
+)
+
+// DeleteOfflinePool deletes the offline pool via control plane plugin
+func DeleteOfflinePool(poolName string, flags ...common.OfflinePoolDelete) error {
+	logf.Log.Info("Deleting offline pool via plugin", "pool", poolName, "flags", flags)
+	err := controlplane.DeleteOfflinePoolViaPlugin(poolName, flags...)
+	if err != nil {
+		logf.Log.Error(err, "Failed to delete offline pool via plugin", "pool", poolName, "flags", flags)
+		return err
+	}
+	return nil
+}

--- a/common/types.go
+++ b/common/types.go
@@ -74,6 +74,7 @@ const (
 // PoolCordonConstraint represents the allowed constraint flags for pool cordon/uncordon operations.
 // Using a typed enum improves type safety over free-form strings.
 type PoolCordonConstraint int
+type OfflinePoolDelete int
 
 const (
 	// CordonReplicas prevents scheduling new replicas on the pool
@@ -84,6 +85,14 @@ const (
 	CordonRestores PoolCordonConstraint = iota
 	// CordonImport prevents importing the pool after node restart
 	CordonImport PoolCordonConstraint = iota
+	// purgePool deletes the pool and all its data without further confirmation
+	PurgePool OfflinePoolDelete = iota
+	// ConfirmPoolDelete requires confirmation to delete the pool
+	ConfirmPoolDelete OfflinePoolDelete = iota
+	// confirmDataLoss requires confirmation to delete the pool if data loss may occur
+	ConfirmDataLoss OfflinePoolDelete = iota
+	// confirmSnapshotLoss requires confirmation to delete the pool if snapshot loss may occur
+	ConfirmSnapshotLoss OfflinePoolDelete = iota
 )
 
 // String returns the CLI flag name corresponding to the constraint.
@@ -97,6 +106,22 @@ func (c PoolCordonConstraint) String() string {
 		return "restores"
 	case CordonImport:
 		return "import"
+	default:
+		return ""
+	}
+}
+
+// String returns the CLI flag name corresponding to the constraint.
+func (c OfflinePoolDelete) String() string {
+	switch c {
+	case PurgePool:
+		return "purge"
+	case ConfirmPoolDelete:
+		return "confirm"
+	case ConfirmDataLoss:
+		return "confirm-data-loss"
+	case ConfirmSnapshotLoss:
+		return "confirm-snapshot-loss"
 	default:
 		return ""
 	}


### PR DESCRIPTION
Added common utility function for offline pool deletion

This PR introduces:
- A function to delete pools using a plugin-based approach, with behavior determined by flags passed to the delete plugin command
- Capability to annotate offline pools for deletion with configurable options
- No API version changes required - this feature extends the existing v1beta3 implementation