### PR TITLE
fix: replace deprecated 'mongo' shell with 'mongosh' for replica set initialization

### DIFF
--- a/apps/mongo.go
+++ b/apps/mongo.go
@@ -329,7 +329,7 @@ func initReplicaSet(ns, name string, replicas int) error {
 	}
 
 	cmd := fmt.Sprintf(
-		`mongo --quiet --eval 'rs.initiate({_id: "%s", members: [%s]})'`,
+		`mongosh --quiet --eval 'rs.initiate({_id: "%s", members: [%s]})'`,
 		MongoReplicaSetName,
 		strings.Join(members, ","),
 	)


### PR DESCRIPTION
The legacy 'mongo' shell command has been replaced with 'mongosh' in MongoDB 5.0+.
This fixes the "command terminated with exit code 127" error during MongoDB replicaset initialisation.