### PR TITLE
feat(dsp-error): add a error messages for pools for the pool expansion tests

### DIFF
--- a/common/custom_resources/api/types/v1beta3/diskpoolcrd.go
+++ b/common/custom_resources/api/types/v1beta3/diskpoolcrd.go
@@ -47,19 +47,20 @@ type DiskPoolDiag struct {
 }
 
 type DiskPoolStatus struct {
-	Available         uint64       `json:"available"`
-	Capacity          uint64       `json:"capacity"`
-	Used              uint64       `json:"used"`
-	CRStatus          string       `json:"cr_state"`
-	PoolStatus        string       `json:"pool_status"`
-	Encrypted         bool         `json:"encrypted"`
-	CapacityQ         string       `json:"capacity_q"`
-	AvailableQ        string       `json:"available_q"`
-	UsedQ             string       `json:"used_q"`
-	ClusterSize       string       `json:"clusterSize"`
-	MaxExpandableSize string       `json:"maxExpandableSize,omitempty"`
-	Conditions        []Condition  `json:"conditions,omitempty"`
-	Diag              DiskPoolDiag `json:"diag,omitempty"`
+	Available         uint64        `json:"available"`
+	Capacity          uint64        `json:"capacity"`
+	Used              uint64        `json:"used"`
+	CRStatus          string        `json:"cr_state"`
+	PoolStatus        string        `json:"pool_status"`
+	Encrypted         bool          `json:"encrypted"`
+	CapacityQ         string        `json:"capacity_q"`
+	AvailableQ        string        `json:"available_q"`
+	UsedQ             string        `json:"used_q"`
+	ClusterSize       string        `json:"clusterSize"`
+	MaxExpandableSize string        `json:"maxExpandableSize,omitempty"`
+	Conditions        []Condition   `json:"conditions,omitempty"`
+	Diag              DiskPoolDiag  `json:"diag,omitempty"`
+	Error             DiskPoolError `json:"error,omitempty"`
 }
 
 type DiskPoolError struct {

--- a/common/custom_resources/types/types.go
+++ b/common/custom_resources/types/types.go
@@ -25,6 +25,9 @@ type DiskPool interface {
 	GetPoolErrorCount() uint64
 	GetPoolAlertStatus() string
 	GetPoolErrorCode() string
+	// Optional: detailed error message (e.g. status.error.message in v1beta3).
+	// May return empty string for CR versions that don't expose it.
+	GetPoolErrorMessage() string
 	GetPoolStatus() string
 	GetClusterSize() string
 	SetClusterSize(clusterSize string) (DiskPool, error)

--- a/common/custom_resources/v1alpha1Ext/dsp.go
+++ b/common/custom_resources/v1alpha1Ext/dsp.go
@@ -333,3 +333,7 @@ func (p v1alpha1ExtDSP) GetPoolAlertStatus() string {
 func (p v1alpha1ExtDSP) GetPoolErrorCode() string {
 	panic(fmt.Errorf("pool error code not supported in v1alpha1Ext"))
 }
+
+func (p v1alpha1ExtDSP) GetPoolErrorMessage() string {
+	panic(fmt.Errorf("pool error message not supported in v1alpha1Ext"))
+}

--- a/common/custom_resources/v1beta1/dsp.go
+++ b/common/custom_resources/v1beta1/dsp.go
@@ -298,3 +298,7 @@ func (p v1beta1DSP) GetPoolAlertStatus() string {
 func (p v1beta1DSP) GetPoolErrorCode() string {
 	panic(fmt.Errorf("pool error code not supported in v1beta1"))
 }
+
+func (p v1beta1DSP) GetPoolErrorMessage() string {
+	panic(fmt.Errorf("pool error message not supported in v1beta1"))
+}

--- a/common/custom_resources/v1beta2/dsp.go
+++ b/common/custom_resources/v1beta2/dsp.go
@@ -317,3 +317,7 @@ func (p v1beta2DSP) GetPoolAlertStatus() string {
 func (p v1beta2DSP) GetPoolErrorCode() string {
 	panic(fmt.Errorf("pool error code not supported in v1beta2"))
 }
+
+func (p v1beta2DSP) GetPoolErrorMessage() string {
+	panic(fmt.Errorf("pool error message not supported in v1beta2"))
+}

--- a/common/custom_resources/v1beta3/dsp.go
+++ b/common/custom_resources/v1beta3/dsp.go
@@ -98,6 +98,15 @@ func (p v1beta3DSP) GetPoolErrorCode() string {
 	return ""
 }
 
+// GetPoolErrorMessage returns the detailed error message from status.error.message
+// when available on the DiskPool CR.
+func (p v1beta3DSP) GetPoolErrorMessage() string {
+	if p.v1beta3 != nil {
+		return p.v1beta3.Status.Error.Message
+	}
+	return ""
+}
+
 func (p v1beta3DSP) GetPoolAlertStatus() string {
 	if p.v1beta3 != nil {
 		return p.v1beta3.Status.Diag.Errors.Status


### PR DESCRIPTION
As with previous releases, expanding a pool with an invalid max expansion value causes the expansion to fail. Previously, the error message was validated from the pool's events, but as of the recent release, the error message now appears directly in the pool spec. This PR adds the functions and error messages needed for that validation