### PR TITLE
feat(dsp-spec): add a check for pool status incase of fallback error

### DIFF
--- a/common/custom_resources/api/types/v1beta3/diskpoolcrd.go
+++ b/common/custom_resources/api/types/v1beta3/diskpoolcrd.go
@@ -47,10 +47,13 @@ type DiskPoolDiag struct {
 }
 
 type DiskPoolStatus struct {
-	Available         uint64        `json:"available"`
-	Capacity          uint64        `json:"capacity"`
-	Used              uint64        `json:"used"`
-	CRStatus          string        `json:"cr_state"`
+	Available uint64 `json:"available"`
+	Capacity  uint64 `json:"capacity"`
+	Used      uint64 `json:"used"`
+	CRStatus  string `json:"cr_state"`
+	// Status is a generic pool state field used by some control-plane versions.
+	// When present, it may carry values like "Offline" even if PoolStatus is empty.
+	Status            string        `json:"status,omitempty"`
 	PoolStatus        string        `json:"pool_status"`
 	Encrypted         bool          `json:"encrypted"`
 	CapacityQ         string        `json:"capacity_q"`

--- a/common/custom_resources/types/types.go
+++ b/common/custom_resources/types/types.go
@@ -29,6 +29,10 @@ type DiskPool interface {
 	// May return empty string for CR versions that don't expose it.
 	GetPoolErrorMessage() string
 	GetPoolStatus() string
+	// GetPoolStatusWithFallback returns the most usable pool state string
+	// across CRD versions, preferring the explicit pool_status field when
+	// present and falling back to generic status/state fields when needed.
+	GetPoolStatusWithFallback() string
 	GetClusterSize() string
 	SetClusterSize(clusterSize string) (DiskPool, error)
 	GetSpecEncryptionSecret() string

--- a/common/custom_resources/v1alpha1Ext/dsp.go
+++ b/common/custom_resources/v1alpha1Ext/dsp.go
@@ -68,6 +68,10 @@ func (p v1alpha1ExtDSP) GetPoolStatus() string {
 	return ""
 }
 
+func (p v1alpha1ExtDSP) GetPoolStatusWithFallback() string {
+	return p.GetPoolStatus()
+}
+
 func (p v1alpha1ExtDSP) GetCRStatus() string {
 	if p.v1alpha1 != nil {
 		if p.extended {

--- a/common/custom_resources/v1beta1/dsp.go
+++ b/common/custom_resources/v1beta1/dsp.go
@@ -61,6 +61,10 @@ func (p v1beta1DSP) GetPoolStatus() string {
 	return ""
 }
 
+func (p v1beta1DSP) GetPoolStatusWithFallback() string {
+	return p.GetPoolStatus()
+}
+
 // For v1beta1 map Status.State to CR status
 func (p v1beta1DSP) GetCRStatus() string {
 	if p.v1beta1 != nil {

--- a/common/custom_resources/v1beta2/dsp.go
+++ b/common/custom_resources/v1beta2/dsp.go
@@ -61,6 +61,10 @@ func (p v1beta2DSP) GetPoolStatus() string {
 	return ""
 }
 
+func (p v1beta2DSP) GetPoolStatusWithFallback() string {
+	return p.GetPoolStatus()
+}
+
 // For v1beta2 map Status.State to CR status
 func (p v1beta2DSP) GetCRStatus() string {
 	if p.v1beta2 != nil {

--- a/common/custom_resources/v1beta3/dsp.go
+++ b/common/custom_resources/v1beta3/dsp.go
@@ -54,10 +54,21 @@ func (p v1beta3DSP) GetName() string {
 	return ""
 }
 
-// For v1beta3 map Status.State to pool status
 func (p v1beta3DSP) GetPoolStatus() string {
 	if p.v1beta3 != nil {
 		return p.v1beta3.Status.PoolStatus
+	}
+	return ""
+}
+
+// GetPoolStatusWithFallback prefers the explicit PoolStatus field when present,
+// falling back to the generic Status field (e.g. "Offline") when PoolStatus is not set.
+func (p v1beta3DSP) GetPoolStatusWithFallback() string {
+	if p.v1beta3 != nil {
+		if p.v1beta3.Status.PoolStatus != "" {
+			return p.v1beta3.Status.PoolStatus
+		}
+		return p.v1beta3.Status.Status
 	}
 	return ""
 }

--- a/common/types.go
+++ b/common/types.go
@@ -197,6 +197,7 @@ type DiskPoolStatus int
 const (
 	DiskPoolOnline   DiskPoolStatus = iota
 	DiskPoolUnknown  DiskPoolStatus = iota
+	DiskPoolOffline  DiskPoolStatus = iota
 	DiskPoolDegraded DiskPoolStatus = iota
 	DiskPoolFaulted  DiskPoolStatus = iota
 )
@@ -207,6 +208,8 @@ func (poolStatus DiskPoolStatus) String() string {
 		return "Online"
 	case DiskPoolUnknown:
 		return "Unknown"
+	case DiskPoolOffline:
+		return "Offline"
 	case DiskPoolDegraded:
 		return "Degraded"
 	case DiskPoolFaulted:


### PR DESCRIPTION
Added a new offline field to reflect cases where the pool CR status is unavailable due to a node issue. Previously, the operator would fabricate an Unknown status when pool_status (sourced from the data-plane) was missing — now it's omitted entirely and replaced with our own perceived status.