### PR TITLE
fix(util): modify the offline pool and node deletion flags

### DIFF
--- a/common/controlplane/v1/msn_cp.go
+++ b/common/controlplane/v1/msn_cp.go
@@ -177,11 +177,13 @@ func (cp CPv1) DeleteOfflineNodeViaPlugin(nodeName string, flags ...common.Offli
 		case common.PurgePool:
 			args = append(args, "--purge")
 		case common.ConfirmPoolDelete:
-			args = append(args, "--confirm")
-		case common.ConfirmDataLoss:
-			args = append(args, "--confirm-data-loss")
-		case common.ConfirmSnapshotLoss:
-			args = append(args, "--confirm-snapshot-loss")
+			args = append(args, "--yes")
+		case common.AcceptDataLoss:
+			args = append(args, "--accept-data-loss")
+		case common.AcceptVolumeLoss:
+			args = append(args, "--accept-volume-loss")
+		case common.AcceptSnapshotLoss:
+			args = append(args, "--accept-snapshot-loss")
 		}
 	}
 

--- a/common/controlplane/v1/msp_cp.go
+++ b/common/controlplane/v1/msp_cp.go
@@ -364,11 +364,15 @@ func (cp CPv1) DeleteOfflinePoolViaPlugin(poolName string, flags ...common.Offli
 		case common.PurgePool:
 			args = append(args, "--purge")
 		case common.ConfirmPoolDelete:
-			args = append(args, "--confirm")
-		case common.ConfirmDataLoss:
-			args = append(args, "--confirm-data-loss")
-		case common.ConfirmSnapshotLoss:
-			args = append(args, "--confirm-snapshot-loss")
+			args = append(args, "--yes")
+		case common.AcceptDataLoss:
+			args = append(args, "--accept-data-loss")
+		case common.AcceptVolumeLoss:
+			args = append(args, "--accept-volume-loss")
+		case common.AcceptSnapshotLoss:
+			args = append(args, "--accept-snapshot-loss")
+		case common.CleanupCr:
+			args = append(args, "--cleanup-cr")
 		}
 	}
 

--- a/common/types.go
+++ b/common/types.go
@@ -89,10 +89,12 @@ const (
 	PurgePool OfflinePoolDelete = iota
 	// ConfirmPoolDelete requires confirmation to delete the pool
 	ConfirmPoolDelete OfflinePoolDelete = iota
-	// confirmDataLoss requires confirmation to delete the pool if data loss may occur
-	ConfirmDataLoss OfflinePoolDelete = iota
-	// confirmSnapshotLoss requires confirmation to delete the pool if snapshot loss may occur
-	ConfirmSnapshotLoss OfflinePoolDelete = iota
+	// AcceptDataLoss requires confirmation to delete the pool if data loss may occur
+	AcceptDataLoss OfflinePoolDelete = iota
+	// AcceptVolumeLoss requires confirmation to delete the pool if volume loss may occur
+	AcceptVolumeLoss OfflinePoolDelete = iota
+	// AcceptSnapshotLoss requires confirmation to delete the pool if snapshot loss may occur
+	AcceptSnapshotLoss OfflinePoolDelete = iota
 	// CleanupCr deletes the DiskPool CR after pool deletion
 	CleanupCr OfflinePoolDelete = iota
 )
@@ -119,11 +121,13 @@ func (c OfflinePoolDelete) String() string {
 	case PurgePool:
 		return "purge"
 	case ConfirmPoolDelete:
-		return "confirm"
-	case ConfirmDataLoss:
-		return "confirm-data-loss"
-	case ConfirmSnapshotLoss:
-		return "confirm-snapshot-loss"
+		return "yes"
+	case AcceptDataLoss:
+		return "accept-data-loss"
+	case AcceptVolumeLoss:
+		return "accept-volume-loss"
+	case AcceptSnapshotLoss:
+		return "accept-snapshot-loss"
 	case CleanupCr:
 		return "cleanup-cr"
 	default:


### PR DESCRIPTION
As part of the recent changes to the offline node and pool deletion feature, the flags used in the tests were modified. This PR incorporates those updates accordingly.