### PR TITLE
feat(node-purge): updated the offline node delete util file name

### DIFF
--- a/common/mayastor/offline_node_delete/offline_node_delete.go
+++ b/common/mayastor/offline_node_delete/offline_node_delete.go
@@ -1,8 +1,12 @@
 package offline_pool_delete
 
 import (
+	"bytes"
+	"fmt"
+
 	"github.com/openebs/openebs-e2e/common"
 	"github.com/openebs/openebs-e2e/common/controlplane"
+	cpv1 "github.com/openebs/openebs-e2e/common/controlplane/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -26,4 +30,27 @@ func DeleteOfflineNode(nodeName string, flags ...common.OfflinePoolDelete) error
 		return err
 	}
 	return nil
+}
+
+// DeleteOfflineNodeWithOutput runs the same kubectl mayastor delete node as DeleteOfflineNode and returns
+// combined stdout/stderr so tests can assert on plugin output (for example data loss / snapshot loss details).
+func DeleteOfflineNodeWithOutput(nodeName string, flags ...common.OfflinePoolDelete) (string, error) {
+	args := []string{"-n", common.NSMayastor(), "delete", "node", nodeName}
+	for _, flag := range flags {
+		// common.OfflinePoolDelete.String() already returns the CLI flag name
+		// (e.g. "purge", "yes", "accept-volume-loss", "accept-snapshot-loss").
+		if s := flag.String(); s != "" {
+			args = append(args, "--"+s)
+		}
+	}
+	logf.Log.Info("Deleting offline node via plugin", "node", nodeName, "args", args)
+	cmd := cpv1.GetMayastorPluginCmd(args...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return out.String(), fmt.Errorf("plugin failed to delete node %s, error %v, output: %s", nodeName, err, out.String())
+	}
+	return out.String(), nil
 }


### PR DESCRIPTION
Renamed the offline node delete utility and added a function to capture stdout/stderr for the node delete command to support output assertion in tests.