### PR TITLE
fix: reduce FsPercent from 60% to 30%

### DIFF
--- a/src/tests/lvm/common/util_resize.go
+++ b/src/tests/lvm/common/util_resize.go
@@ -49,7 +49,7 @@ func LvmVolumeResizeTest(decor string, engine common.OpenEbsEngine, vgName strin
 	}
 
 	if ResizeApp.FsType == common.BtrfsFsType {
-		ResizeApp.FsPercent = 60
+		ResizeApp.FsPercent = 30
 	}
 
 	logf.Log.Info("create sc, pvc, fio pod")


### PR DESCRIPTION
lvm btrfs re-size tests were failing due to fio app erroring out with "No space left on device" issue. fsPercent value set to 60% seemed to be high and while fio was doing i/o , resized space(2GB) wasn't  insufficient. I reduced fsPercent value to 30% and verified it and tests are passing - https://github.com/openebs/openebs-e2e/actions/runs/23742591866/job/69164321695