### PR TITLE
feat[pool-purge]: updated the pool purge annotation format

### DIFF
--- a/common/controlplane/v1/msn_cp.go
+++ b/common/controlplane/v1/msn_cp.go
@@ -184,6 +184,8 @@ func (cp CPv1) DeleteOfflineNodeViaPlugin(nodeName string, flags ...common.Offli
 			args = append(args, "--accept-volume-loss")
 		case common.AcceptSnapshotLoss:
 			args = append(args, "--accept-snapshot-loss")
+		case common.IgnoreNotFound:
+			args = append(args, "--ignore-not-found")
 		}
 	}
 

--- a/common/custom_resources/v1beta3/dsp.go
+++ b/common/custom_resources/v1beta3/dsp.go
@@ -595,14 +595,16 @@ func (ifc v1beta3Ifc) VerifyPoolCapacityAndMaxExpansion(poolName string, expecte
 	return nil
 }
 
-// AnnotateOfflinePoolForDelete adds per-option annotations for offline pool deletion
-// with specified options passed as strings.
+// AnnotateOfflinePoolForDelete annotates a DiskPool CR to configure annotation-based delete/purge.
+//
+// The diskpool operator consumes the `openebs.io/delete-opts` annotation.
 // Supported options:
-//   - purge              -> annotation "purge": "true"
-//   - accept             -> annotation "accept": "true"
-//   - accept_volume_loss -> annotation "accept_volume_loss": "true"
-//   - accept_snapshot_loss -> annotation "accept_snapshot_loss": "true"
-//   - accept_data_loss   -> annotation "accept_data_loss": "true"
+//   - purge                -> "purge=true"
+//   - accept               -> "accept=true"
+//   - accept_volume_loss   -> "accept-volume-loss=true"
+//   - accept_snapshot_loss -> "accept-snapshot-loss=true"
+//   - accept_data_loss     -> "accept-data-loss=true"
+//   - purge_accept_all     -> "purge-accept-all"
 func (ifc v1beta3Ifc) AnnotateOfflinePoolForDelete(poolName string, opts ...string) error {
 	res, err := poolClientSet.DiskPools().Get(context.TODO(), poolName, metaV1.GetOptions{})
 	if err != nil {
@@ -635,29 +637,39 @@ func (ifc v1beta3Ifc) AnnotateOfflinePoolForDelete(poolName string, opts ...stri
 	return nil
 }
 
-// buildDeleteOptsAnnotations constructs a single annotation whose value is a YAML
-// block listing the delete options as key: true entries. This ensures that the
-// DiskPool YAML shows:
+// buildDeleteOptsAnnotations constructs the `openebs.io/delete-opts` annotation value.
 //
-//	annotations:
-//	  openebs.io/delete-opts: |
-//	    purge: true
-//	    accept: true
+// New format: inline comma-separated values, e.g.
+//
+//	openebs.io/delete-opts: purge=true,accept=true,accept-volume-loss=true,accept-snapshot-loss=true
+//
+// It also supports a shorthand:
+//
+//	openebs.io/delete-opts: purge-accept-all
 func (ifc v1beta3Ifc) buildDeleteOptsAnnotations(opts ...string) map[string]string {
+	// Prefer shorthand if explicitly requested.
+	for _, opt := range opts {
+		if opt == "purge_accept_all" || opt == "purge-accept-all" {
+			return map[string]string{
+				"openebs.io/delete-opts": "purge-accept-all",
+			}
+		}
+	}
+
 	results := []string{}
 
 	for _, opt := range opts {
 		switch opt {
 		case "purge":
-			results = append(results, "purge: true")
+			results = append(results, "purge=true")
 		case "accept":
-			results = append(results, "accept: true")
+			results = append(results, "accept=true")
 		case "accept_volume_loss":
-			results = append(results, "accept_volume_loss: true")
+			results = append(results, "accept-volume-loss=true")
 		case "accept_snapshot_loss":
-			results = append(results, "accept_snapshot_loss: true")
+			results = append(results, "accept-snapshot-loss=true")
 		case "accept_data_loss":
-			results = append(results, "accept_data_loss: true")
+			results = append(results, "accept-data-loss=true")
 		}
 	}
 
@@ -665,8 +677,8 @@ func (ifc v1beta3Ifc) buildDeleteOptsAnnotations(opts ...string) map[string]stri
 		return map[string]string{}
 	}
 
-	// Store all options under the openebs.io/delete-opts key so kubectl prints a block.
+	// Store all options under the openebs.io/delete-opts key.
 	return map[string]string{
-		"openebs.io/delete-opts": strings.Join(results, "\n"),
+		"openebs.io/delete-opts": strings.Join(results, ","),
 	}
 }

--- a/common/mayastor/offline_node_delete/offline_node_delete.go
+++ b/common/mayastor/offline_node_delete/offline_node_delete.go
@@ -23,10 +23,10 @@ var (
 
 // DeleteOfflineNode deletes the offline Node via control plane plugin
 func DeleteOfflineNode(nodeName string, flags ...common.OfflinePoolDelete) error {
-	logf.Log.Info("Deleting offline pool via plugin", "pool", nodeName, "flags", flags)
+	logf.Log.Info("Deleting offline node via plugin", "node", nodeName, "flags", flags)
 	err := controlplane.DeleteOfflineNodeViaPlugin(nodeName, flags...)
 	if err != nil {
-		logf.Log.Error(err, "Failed to delete offline pool via plugin", "pool", nodeName, "flags", flags)
+		logf.Log.Error(err, "Failed to delete offline node via plugin", "node", nodeName, "flags", flags)
 		return err
 	}
 	return nil

--- a/common/mayastor/offline_pool_delete/offline_pool_delete.go
+++ b/common/mayastor/offline_pool_delete/offline_pool_delete.go
@@ -1,10 +1,12 @@
 package offline_pool_delete
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/openebs/openebs-e2e/common"
 	"github.com/openebs/openebs-e2e/common/controlplane"
+	cpv1 "github.com/openebs/openebs-e2e/common/controlplane/v1"
 	"github.com/openebs/openebs-e2e/common/custom_resources"
 	"github.com/openebs/openebs-e2e/common/k8stest"
 
@@ -33,6 +35,27 @@ func DeleteOfflinePool(poolName string, flags ...common.OfflinePoolDelete) error
 		return err
 	}
 	return nil
+}
+
+// DeleteOfflinePoolWithOutput runs kubectl mayastor delete pool and returns combined stdout/stderr
+// so tests can assert on plugin output (for example data loss / snapshot loss details).
+func DeleteOfflinePoolWithOutput(poolName string, flags ...common.OfflinePoolDelete) (string, error) {
+	args := []string{"-n", common.NSMayastor(), "delete", "pool", poolName}
+	for _, flag := range flags {
+		if s := flag.String(); s != "" {
+			args = append(args, "--"+s)
+		}
+	}
+	logf.Log.Info("Deleting offline pool via plugin", "pool", poolName, "args", args)
+	cmd := cpv1.GetMayastorPluginCmd(args...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return out.String(), fmt.Errorf("plugin failed to delete pool %s, error %v, output: %s", poolName, err, out.String())
+	}
+	return out.String(), nil
 }
 
 // GetNodeNameFromPool returns the node name for a given pool.


### PR DESCRIPTION
This PR updates the annotation format to align with recent offline pool deletion changes — switching from a multi-line YAML block to an inline comma-separated format: openebs.io/delete-opts: purge=true,accept=true,accept-volume-loss=true,accept-snapshot-loss=true