### PR TITLE
fix: refactoring specificschema pool creation logic 

### DIFF
--- a/common/mayastor/pool_expansion/pool_expansion.go
+++ b/common/mayastor/pool_expansion/pool_expansion.go
@@ -568,40 +568,71 @@ func CreateEncryptedPoolsWithMaxExpansionOnAllNodes(allNodes []string, encryptio
 	return createdPools, nil
 }
 
+func CreatePoolsWithSpecificSchemaOnNodesWithDevices(nodeDeviceMap map[string]string, schema DeviceSchema, maxExpansionStr string, clusterSizeArg string) (createdPools []string, err error) {
+
+	createdPools = make([]string, 0)
+
+	for nodeName, device := range nodeDeviceMap {
+		if device == "" {
+			logf.Log.Info("Skipping node without device", "node", nodeName)
+			continue
+		}
+
+		schemaStr := schema.String()
+
+		var schemaDevice string
+		if schemaStr == "" {
+			schemaDevice = device
+		} else {
+			schemaDevice = fmt.Sprintf("%s://%s", schemaStr, device)
+		}
+
+		poolName := fmt.Sprintf("pool-expansion-test-%s", nodeName)
+
+		logf.Log.Info("Creating pool with schema, MaxExpansion and ClusterSize",
+			"poolName", poolName,
+			"clusterSize", clusterSizeArg,
+			"schema", schemaStr,
+			"device", device,
+		)
+
+		if err = CreatePoolWithMaxAndCluster(poolName, nodeName, schemaDevice, maxExpansionStr, clusterSizeArg); err != nil {
+			return
+		}
+
+		createdPools = append(createdPools, poolName)
+	}
+
+	if len(createdPools) == 0 {
+		err = fmt.Errorf("no pools could be created on any node")
+	}
+
+	return createdPools, err
+}
+
 // CreatePoolsWithSpecificSchemaOnAllNodes creates a pool on each provided node using
 // the given schema prefix for the device path (e.g., "uring://"), MaxExpansion and ClusterSize.
 // It returns the created pool names.
 func CreatePoolsWithSpecificSchemaOnAllNodes(allNodes []string, schema DeviceSchema, maxExpansionStr string, clusterSizeArg string) (createdPools []string, err error) {
-	createdPools = make([]string, 0)
+
+	nodeDeviceMap := make(map[string]string)
 
 	for _, nodeName := range allNodes {
-		// Get the first available disk on this node
 		devices, deviceErr := k8stest.GetConfiguredNodePoolDevices(nodeName)
 		if deviceErr != nil || len(devices) == 0 {
 			logf.Log.Info("Skipping node without configured pool device", "node", nodeName, "err", deviceErr)
 			continue
 		}
-		// Prefix the device path with the requested schema (e.g., uring://<device>)
-		schemaStr := schema.String()
-		var schemaDevice string
-		if schemaStr == "" {
-			schemaDevice = devices[0]
-		} else {
-			schemaDevice = fmt.Sprintf("%s://%s", schemaStr, devices[0])
-		}
 
-		poolName := fmt.Sprintf("pool-expansion-test-%s", nodeName)
-		logf.Log.Info("Creating pool with schema, MaxExpansion and ClusterSize", "poolName", poolName, "clusterSize", clusterSizeArg, "schema", schemaStr)
-		if err = CreatePoolWithMaxAndCluster(poolName, nodeName, schemaDevice, maxExpansionStr, clusterSizeArg); err != nil {
-			return
-		}
-		createdPools = append(createdPools, poolName)
+		nodeDeviceMap[nodeName] = devices[0]
 	}
-	if len(createdPools) == 0 {
-		err = fmt.Errorf("no pools could be created on any node")
-		return
-	}
-	return createdPools, nil
+
+	return CreatePoolsWithSpecificSchemaOnNodesWithDevices(
+		nodeDeviceMap,
+		schema,
+		maxExpansionStr,
+		clusterSizeArg,
+	)
 }
 
 // VerifyPoolDiskSchema verifies that all pools have the expected disk schema (e.g., "uring" or "aio").


### PR DESCRIPTION
As part of this PR, refactored specificschema pool creation code to allow passing of device as well(needed for disk failures test) without impacting the current test pool_expansion_for_uring_pool_schema which uses the existing CreatePoolsWithSpecificSchemaOnAllNodes().

Tested the existing with my changes locally , uring pool created successfully

` 2026-04-17T05:35:43Z	INFO	Creating pool with schema, MaxExpansion and ClusterSize	{"poolName": "pool-expansion-test-node-2-459189", "clusterSize": "4MiB", "schema": "uring", "device": "/dev/disk/by-id/scsi-0HC_Volume_105372183"}
W0417 05:35:44.055694 3608066 warnings.go:70] unknown field "status.diag.errors"
  2026-04-17T05:35:44Z	INFO	Creating pool with schema, MaxExpansion and ClusterSize	{"poolName": "pool-expansion-test-node-0-459189", "clusterSize": "4MiB", "schema": "uring", "device": "/dev/disk/by-id/scsi-0HC_Volume_105372184"}
W0417 05:35:44.222774 3608066 warnings.go:70] unknown field "status.diag.errors"
  2026-04-17T05:35:44Z	INFO	Creating pool with schema, MaxExpansion and ClusterSize	{"poolName": "pool-expansion-test-node-1-459189", "clusterSize": "4MiB", "schema": "uring", "device": "/dev/disk/by-id/scsi-0HC_Volume_105372185"}
W0417 05:35:44.389743 3608066 warnings.go:70] unknown field "status.diag.errors"
  2026-04-17T05:35:49Z	INFO	Pools created successfully	{"pools": ["pool-expansion-test-node-2-459189", "pool-expansion-test-node-0-459189", "pool-expansion-test-node-1-459189"], "maxExpansion": "150GiB"}
  2026-04-17T05:35:50Z	INFO	Verified pool has expected disk schema	{"poolName": "pool-expansion-test-node-2-459189", "schema": "uring", "disk": "uring:///dev/disk/by-id/scsi-0HC_Volume_105372183"}
  2026-04-17T05:35:51Z	INFO	Verified pool has expected disk schema	{"poolName": "pool-expansion-test-node-0-459189", "schema": "uring", "disk": "uring:///dev/disk/by-id/scsi-0HC_Volume_105372184"}
  2026-04-17T05:35:52Z	INFO	Verified pool has expected disk schema	{"poolName": "pool-expansion-test-node-1-459189", "schema": "uring", "disk": "uring:///dev/disk/by-id/scsi-0HC_Volume_105372185"}
  2026-04-17T05:35:53Z	INFO	Captured initial pool state	{"poolName": "pool-expansion-test-node-2-459189", "initialCapacity": 10578034688, "diskCapacityBytes": 10737418240, "maxExpandableBytes": 274710134784}
  2026-04-17T05:35:55Z	INFO	Captured initial pool state	{"poolName": "pool-expansion-test-node-0-459189", "initialCapacity": 10578034688, "diskCapacityBytes": 10737418240, "maxExpandableBytes": 274710134784}
  2026-04-17T05:35:56Z	INFO	Captured initial pool state	{"poolName": "pool-expansion-test-node-1-459189", "initialCapacity": 10578034688, "diskCapacityBytes": 10737418240, "maxExpandableBytes": 274710134784}
  2026-04-17T05:35:56Z	INFO	Verifying MaxExpandableBytes and disk capacity via control-plane for all pools	{"pools": ["pool-expansion-test-node-2-459189", "pool-expansion-test-node-0-459189", "pool-expansion-test-node-1-459189"], "expectedMaxExpansion": "150GiB", "clusterSize": "4MiB"}`