### PR TITLE
fix: update disk pool event message for invalid cluster type

### DIFF
--- a/common/mayastor/dsp_cluster_size/dsp_cluster_size.go
+++ b/common/mayastor/dsp_cluster_size/dsp_cluster_size.go
@@ -12,7 +12,7 @@ import (
 )
 
 var poolOnlineTimeoutSec = 120 // seconds
-var DspClusterSizeInvalidSizeMessage = "Invalid cluster-size"
+var DspClusterSizeInvalidSizeMessage = "InvalidArgument: invalid cluster-size"
 var NotEnoughSuitablePoolsMessage = "Not enough suitable pools available"
 
 func SetMayastorDspClusterSize(size, helmChart, helmRelease, helmVersion string) error {


### PR DESCRIPTION
Fixed the event message for disk pool creation failures caused by invalid cluster size