### PR TITLE
feat(events): add plugin-based eventing framework with typed enums and helper utilities

### DIFF
--- a/common/controlplane/controlplane.go
+++ b/common/controlplane/controlplane.go
@@ -131,6 +131,10 @@ type ControlPlaneInterface interface {
 
 	// Node deletion abstraction
 	DeleteOfflineNodeViaPlugin(nodeName string, constraints ...common.OfflinePoolDelete) error
+
+	// Events
+	GetEvents(flags ...string) ([]common.EventRecord, error)
+	CountEvents(flags ...string) int
 }
 
 var ifc ControlPlaneInterface
@@ -527,4 +531,12 @@ func DeleteOfflinePoolViaPlugin(poolName string, flags ...common.OfflinePoolDele
 
 func DeleteOfflineNodeViaPlugin(nodeName string, flags ...common.OfflinePoolDelete) error {
 	return getControlPlane().DeleteOfflineNodeViaPlugin(nodeName, flags...)
+}
+
+func GetEvents(flags ...string) ([]common.EventRecord, error) {
+	return getControlPlane().GetEvents(flags...)
+}
+
+func CountEvents(flags ...string) int {
+	return getControlPlane().CountEvents(flags...)
 }

--- a/common/controlplane/v1-rest-api/events.go
+++ b/common/controlplane/v1-rest-api/events.go
@@ -1,0 +1,15 @@
+package v1_rest_api
+
+import (
+	"fmt"
+
+	"github.com/openebs/openebs-e2e/common"
+)
+
+func (cp CPv1RestApi) GetEvents(flags ...string) ([]common.EventRecord, error) {
+	panic(fmt.Errorf("not implemented REST api"))
+}
+
+func (cp CPv1RestApi) CountEvents(flags ...string) int {
+	panic(fmt.Errorf("not implemented REST api"))
+}

--- a/common/controlplane/v1/events.go
+++ b/common/controlplane/v1/events.go
@@ -1,0 +1,34 @@
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/openebs/openebs-e2e/common"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func (cp CPv1) GetEvents(flags ...string) ([]common.EventRecord, error) {
+	args := append([]string{"get", "events", "-n", common.NSMayastor(), "-o", "json"}, flags...)
+	cmd := GetMayastorPluginCmd(args...)
+	jsonInput, err := cmd.CombinedOutput()
+	err = CheckPluginError(jsonInput, err)
+	if err != nil {
+		return nil, err
+	}
+	var records []common.EventRecord
+	if err := json.Unmarshal(jsonInput, &records); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal events JSON: %w, output: %s", err, string(jsonInput))
+	}
+	return records, nil
+}
+
+func (cp CPv1) CountEvents(flags ...string) int {
+	records, err := cp.GetEvents(flags...)
+	if err != nil {
+		logf.Log.Info("CountEvents: failed to get events", "error", err)
+		return 0
+	}
+	return len(records)
+}

--- a/common/e2e_config/e2e_config.go
+++ b/common/e2e_config/e2e_config.go
@@ -64,6 +64,7 @@ type ProductSpec struct {
 	OpenEBSHelmReleaseName           string   `yaml:"openEBSHelmReleaseName"`
 	IOEnginePodLabelValue            string   `yaml:"ioEnginePodLabelValue" env-default:"io-engine"`
 	IOEnginePodName                  string   `yaml:"ioEnginePodName"`
+	EventingAggregatorDeployment     string   `yaml:"eventingAggregatorDeployment"`
 	JaegersCrdName                   string   `yaml:"jaegersCrdName" env-default:"jaegers.jaegertracing.io"`
 	KubectlPluginName                string   `yaml:"kubectlPluginName" env-default:"kubectl-mayastor" env:"e2e_kc_plugin"`
 	KubectlOpenebsPluginName         string   `yaml:"kubectlOpenebsPluginName" env-default:"kubectl-openebs"`

--- a/common/e2e_ginkgo/e2e_ginkgo.go
+++ b/common/e2e_ginkgo/e2e_ginkgo.go
@@ -8,13 +8,10 @@ import (
 
 	"github.com/openebs/openebs-e2e/common"
 	"github.com/openebs/openebs-e2e/common/e2e_config"
-	"github.com/openebs/openebs-e2e/common/event"
 	"github.com/openebs/openebs-e2e/common/k8stest"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-
-	"gopkg.in/yaml.v3"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -174,34 +171,6 @@ func afterEachCheckResources(canGenSupportBundle bool) error {
 			k8stest.GenerateSupportBundle(logsPath + "-AfterEach")
 		} else {
 			log.Log.Info("test case logs path was not set")
-		}
-	}
-	eventMessages, err := event.GetAllEventMessagesSymbolic()
-	if err != nil {
-		log.Log.Info("failed to retrieve events", "error", err)
-		// log the error -but do not fail the test case
-		err = nil
-	} else {
-		yml, err := yaml.Marshal(eventMessages)
-		if err != nil {
-			log.Log.Info("failed to deserialise events", "error", err)
-		} else {
-			logsPath, err := common.GetTestCaseLogsPath()
-			if err != nil {
-				log.Log.Info("failed to retrieve logs path", "error", err)
-			} else {
-				err = os.MkdirAll(logsPath, 0755)
-				if err != nil {
-					log.Log.Info("Failed to create path", logsPath, err)
-				} else {
-					err = os.WriteFile(logsPath+"/events.yml", yml, 0644)
-					if err != nil {
-						log.Log.Info("failed to write", logsPath+"/events.yml", err)
-					} else {
-						log.Log.Info("events collected", "at", logsPath+"/events.yml")
-					}
-				}
-			}
 		}
 	}
 	common.ResetTestCaseLogsPath()

--- a/common/mayastor/events/events.go
+++ b/common/mayastor/events/events.go
@@ -1,0 +1,511 @@
+package events
+
+// Package events provides CLI filter constants, helper functions, and
+// reusable utilities for the eventing aggregator plugin.
+// Enum types and event struct types live in common/types.go.
+// Plugin execution functions live in controlplane/v1.
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/openebs/openebs-e2e/common"
+	"github.com/openebs/openebs-e2e/common/controlplane"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// ── Default timeouts ──
+
+const (
+	DefaultTimeout      = 60 * time.Second
+	DefaultPollInterval = 3 * time.Second
+)
+
+// ── FilterOption builds CLI flag pairs for plugin queries ──
+
+type FilterOption func() []string
+
+// WithCategory adds --category flag to filter events by category (e.g. "pool", "volume", "nexus").
+func WithCategory(filter string) FilterOption {
+	return func() []string { return []string{FlagCategory, filter} }
+}
+
+// WithAction adds --action flag to filter events by action (e.g. "create", "delete", "state-change").
+func WithAction(filter string) FilterOption {
+	return func() []string { return []string{FlagAction, filter} }
+}
+
+// WithComponent adds --component flag to filter events by source component (e.g. "core-agent", "io-engine").
+func WithComponent(filter string) FilterOption {
+	return func() []string { return []string{FlagComponent, filter} }
+}
+
+// WithNode adds --node flag to filter events by the node name that generated them.
+func WithNode(node string) FilterOption {
+	return func() []string { return []string{FlagNode, node} }
+}
+
+// WithTarget adds --target flag to filter events by target UUID (volume, nexus, replica, etc.).
+func WithTarget(target string) FilterOption {
+	return func() []string { return []string{FlagTarget, target} }
+}
+
+// WithPool adds --pool flag to filter events by pool name or UUID.
+func WithPool(pool string) FilterOption {
+	return func() []string { return []string{FlagPool, pool} }
+}
+
+// WithVolume adds --volume flag to filter events by volume UUID.
+func WithVolume(volume string) FilterOption {
+	return func() []string { return []string{FlagVolume, volume} }
+}
+
+// WithReplica adds --replica flag to filter events by replica UUID.
+func WithReplica(replica string) FilterOption {
+	return func() []string { return []string{FlagReplica, replica} }
+}
+
+// WithRebuildStatusFilter adds --rebuild-status flag to filter rebuild events by status (e.g. "started", "completed").
+func WithRebuildStatusFilter(status string) FilterOption {
+	return func() []string { return []string{FlagRebuildStatus, status} }
+}
+
+// WithState adds --state flag to filter events by state value.
+func WithState(state string) FilterOption {
+	return func() []string { return []string{FlagState, state} }
+}
+
+// WithFilter adds --filter flag for free-form text filtering on event records.
+func WithFilter(filter string) FilterOption {
+	return func() []string { return []string{FlagFilter, filter} }
+}
+
+// WithSince adds --since flag to filter events from a relative duration (e.g. "5m", "1h").
+func WithSince(duration string) FilterOption {
+	return func() []string { return []string{FlagSince, duration} }
+}
+
+// WithLimit adds --limit flag to cap the number of returned events.
+func WithLimit(limit int) FilterOption {
+	return func() []string { return []string{FlagLimit, strconv.Itoa(limit)} }
+}
+
+// BuildFlags collects all FilterOption functions into a flat slice of CLI flag pairs.
+func BuildFlags(opts ...FilterOption) []string {
+	var flags []string
+	for _, opt := range opts {
+		flags = append(flags, opt()...)
+	}
+	return flags
+}
+
+// ── Query helpers ──
+
+// GetEvents queries the plugin for events matching the given filters and returns them newest-first.
+func GetEvents(opts ...FilterOption) ([]common.EventRecord, error) {
+	return controlplane.GetEvents(BuildFlags(opts...)...)
+}
+
+// EventsCount returns the number of events matching the given filters.
+func EventsCount(opts ...FilterOption) int {
+	return controlplane.CountEvents(BuildFlags(opts...)...)
+}
+
+// IsEventFound returns true if at least one event matches the given filters.
+func IsEventFound(opts ...FilterOption) bool {
+	return EventsCount(opts...) > 0
+}
+
+// ── Wait helpers ──
+
+// WaitForEvents polls until at least 1 event matches the filters, using DefaultTimeout.
+func WaitForEvents(opts ...FilterOption) ([]common.EventRecord, error) {
+	return WaitForEventCountWithTimeout(1, DefaultTimeout, opts...)
+}
+
+// WaitForEventCount polls until at least count events match the filters, using DefaultTimeout.
+func WaitForEventCount(count int, opts ...FilterOption) ([]common.EventRecord, error) {
+	return WaitForEventCountWithTimeout(count, DefaultTimeout, opts...)
+}
+
+// WaitForEventCountWithTimeout polls until at least count events match or the timeout expires.
+func WaitForEventCountWithTimeout(count int, timeout time.Duration, opts ...FilterOption) ([]common.EventRecord, error) {
+	var records []common.EventRecord
+	deadline := time.Now().Add(timeout)
+	flags := BuildFlags(opts...)
+	for {
+		var err error
+		records, err = controlplane.GetEvents(flags...)
+		if err == nil && len(records) >= count {
+			return records, nil
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		if err != nil {
+			logf.Log.Info("WaitForEventCountWithTimeout", "poll error", err)
+		}
+		time.Sleep(DefaultPollInterval)
+	}
+	return records, fmt.Errorf("timed out waiting for %d events (got %d) after %v",
+		count, len(records), timeout)
+}
+
+// EventCount returns a closure suitable for Gomega Eventually that polls the matching event count.
+func EventCount(opts ...FilterOption) func() int {
+	flags := BuildFlags(opts...)
+	return func() int {
+		return controlplane.CountEvents(flags...)
+	}
+}
+
+// ── Client-side filters (post-retrieval) ──
+
+// FilterEventByCategory filters a pre-fetched event slice to only records matching the given category.
+func FilterEventByCategory(records []common.EventRecord, category common.EventCategory) []common.EventRecord {
+	var result []common.EventRecord
+	for _, r := range records {
+		if r.Category == category {
+			result = append(result, r)
+		}
+	}
+	return result
+}
+
+// FilterEventByAction filters a pre-fetched event slice to only records matching the given action.
+func FilterEventByAction(records []common.EventRecord, action common.EventAction) []common.EventRecord {
+	var result []common.EventRecord
+	for _, r := range records {
+		if r.Action == action {
+			result = append(result, r)
+		}
+	}
+	return result
+}
+
+// FilterEventByTarget filters a pre-fetched event slice to only records matching the given target UUID.
+func FilterEventByTarget(records []common.EventRecord, target string) []common.EventRecord {
+	var result []common.EventRecord
+	for _, r := range records {
+		if r.Target == target {
+			result = append(result, r)
+		}
+	}
+	return result
+}
+
+// FilterEventByComponent filters a pre-fetched event slice to only records from the given source component.
+func FilterEventByComponent(records []common.EventRecord, component common.EventComponent) []common.EventRecord {
+	var result []common.EventRecord
+	for _, r := range records {
+		if r.Metadata.Source.Component == component {
+			result = append(result, r)
+		}
+	}
+	return result
+}
+
+// GetRebuildEventsDetails extracts RebuildDetails from an event record, returns nil if absent.
+func GetRebuildEventsDetails(record common.EventRecord) *common.RebuildDetails {
+	if record.Metadata.Source.EventDetails == nil {
+		return nil
+	}
+	return record.Metadata.Source.EventDetails.RebuildDetails
+}
+
+// GetSwitchOverEventDetails extracts SwitchOverDetails from an event record, returns nil if absent.
+func GetSwitchOverEventDetails(record common.EventRecord) *common.SwitchOverDetails {
+	if record.Metadata.Source.EventDetails == nil {
+		return nil
+	}
+	return record.Metadata.Source.EventDetails.SwitchOverDetails
+}
+
+// GetStateChangeEventDetails extracts StateChangeDetails from an event record, returns nil if absent.
+func GetStateChangeEventDetails(record common.EventRecord) *common.StateChangeDetails {
+	if record.Metadata.Source.EventDetails == nil {
+		return nil
+	}
+	return record.Metadata.Source.EventDetails.StateChangeDetails
+}
+
+// GetSnapshotEventDetails extracts SnapshotDetails from an event record, returns nil if absent.
+func GetSnapshotEventDetails(record common.EventRecord) *common.SnapshotDetails {
+	if record.Metadata.Source.EventDetails == nil {
+		return nil
+	}
+	return record.Metadata.Source.EventDetails.SnapshotDetails
+}
+
+// GetNvmePathEventDetails extracts NvmePathDetails from an event record, returns nil if absent.
+func GetNvmePathEventDetails(record common.EventRecord) *common.NvmePathDetails {
+	if record.Metadata.Source.EventDetails == nil {
+		return nil
+	}
+	return record.Metadata.Source.EventDetails.NvmePathDetails
+}
+
+// GetReplicaEventDetails extracts ReplicaDetails from an event record, returns nil if absent.
+func GetReplicaEventDetails(record common.EventRecord) *common.ReplicaDetails {
+	if record.Metadata.Source.EventDetails == nil {
+		return nil
+	}
+	return record.Metadata.Source.EventDetails.ReplicaDetails
+}
+
+// GetReactorEventDetails extracts ReactorDetails from an event record, returns nil if absent.
+func GetReactorEventDetails(record common.EventRecord) *common.ReactorDetails {
+	if record.Metadata.Source.EventDetails == nil {
+		return nil
+	}
+	return record.Metadata.Source.EventDetails.ReactorDetails
+}
+
+// GetErrorEventDetails extracts ErrorDetails from an event record, returns nil if absent.
+func GetErrorEventDetails(record common.EventRecord) *common.ErrorDetails {
+	if record.Metadata.Source.EventDetails == nil {
+		return nil
+	}
+	return record.Metadata.Source.EventDetails.ErrorDetails
+}
+
+// GetNexusChildEventDetails extracts NexusChildDetails from an event record, returns nil if absent.
+func GetNexusChildEventDetails(record common.EventRecord) *common.NexusChildDetails {
+	if record.Metadata.Source.EventDetails == nil {
+		return nil
+	}
+	return record.Metadata.Source.EventDetails.NexusChildDetails
+}
+
+// ── Event metadata verification helpers ──
+
+// CheckRebuildEvent validates rebuild event metadata: source/dest URIs, error presence, and rebuild status.
+func CheckRebuildEvent(
+	record *common.EventRecord,
+	sourceUri string,
+	destUri string,
+	hasErr bool,
+	rebuildStatus common.RebuildStatus) error {
+
+	details := GetRebuildEventsDetails(*record)
+	if details == nil {
+		return fmt.Errorf("event is missing rebuild details")
+	}
+
+	if hasErr {
+		if details.Error == "" {
+			return fmt.Errorf("event is missing error message")
+		}
+	} else {
+		if details.Error != "" {
+			return fmt.Errorf("event has error message: %s", details.Error)
+		}
+	}
+
+	if details.SourceReplica != sourceUri {
+		return fmt.Errorf(
+			"event has invalid source uri, expected %s, got: %s",
+			sourceUri, details.SourceReplica,
+		)
+	}
+
+	if details.DestinationReplica != destUri {
+		return fmt.Errorf(
+			"event has invalid destination uri, expected %s, got: %s",
+			destUri, details.DestinationReplica,
+		)
+	}
+
+	if details.RebuildStatus != rebuildStatus {
+		return fmt.Errorf(
+			"event has invalid rebuild status, expected %s, got: %s",
+			string(rebuildStatus), string(details.RebuildStatus),
+		)
+	}
+	return nil
+}
+
+// VerifyHASwitchoverEventMetadata validates switchover event status and new path (empty for Started, device URI for Completed).
+func VerifyHASwitchoverEventMetadata(record *common.EventRecord, switchoverStatus common.SwitchOverStatus, newPath string) error {
+
+	details := GetSwitchOverEventDetails(*record)
+	if details == nil {
+		return fmt.Errorf("event is missing switchover details")
+	}
+
+	if details.SwitchOverStatus != switchoverStatus {
+		return fmt.Errorf(
+			"switchover status does not match with switchover events metadata, expected: %v, got: %v",
+			switchoverStatus, details.SwitchOverStatus,
+		)
+	}
+
+	if switchoverStatus == common.SwitchOverStarted {
+		if details.NewPath != "" {
+			return fmt.Errorf(
+				"new path should be a empty string when switchover started event generated, but got: %s",
+				details.NewPath,
+			)
+		}
+	}
+
+	if switchoverStatus == common.SwitchOverCompleted {
+		if details.NewPath != newPath {
+			return fmt.Errorf(
+				"new path does not match with switchover events metadata, expected: %s, got: %s",
+				newPath, details.NewPath,
+			)
+		}
+	}
+
+	return nil
+}
+
+// VerifyNexusChildEventMetadata validates that the nexus child event contains the expected URI.
+func VerifyNexusChildEventMetadata(record *common.EventRecord, uri string) error {
+
+	details := GetNexusChildEventDetails(*record)
+	if details == nil {
+		return fmt.Errorf("event is missing nexus child details")
+	}
+
+	if details.Uri != uri {
+		return fmt.Errorf(
+			"nexus child uri does not match with nexus child event metadata, expected: %s, got: %s",
+			uri, details.Uri,
+		)
+	}
+	return nil
+}
+
+// VerifyReplicaEventMetadata validates that the replica event contains the expected pool name and replica name.
+func VerifyReplicaEventMetadata(record *common.EventRecord, poolName string, replicaName string) error {
+
+	details := GetReplicaEventDetails(*record)
+	if details == nil {
+		return fmt.Errorf("event is missing replica details")
+	}
+
+	if details.PoolName != poolName {
+		return fmt.Errorf(
+			"replica pool name does not match with replica events metadata, expected: %s, got: %s",
+			poolName, details.PoolName,
+		)
+	}
+
+	if details.ReplicaName != replicaName {
+		return fmt.Errorf(
+			"replica name does not match with replica events metadata, expected: %s, got: %s",
+			replicaName, details.ReplicaName,
+		)
+	}
+
+	return nil
+}
+
+// VerifyNvmePathEventMetadata validates that the NVMe path event's NQN contains the given volume UUID.
+func VerifyNvmePathEventMetadata(record *common.EventRecord, uuid string) error {
+
+	details := GetNvmePathEventDetails(*record)
+	if details == nil {
+		return fmt.Errorf("event is missing nvme path details")
+	}
+
+	if !strings.Contains(details.Nqn, uuid) {
+		return fmt.Errorf(
+			"nvmePath nqn does not match with nvmePath events metadata, expected: %v, got: %v",
+			uuid, details.Nqn,
+		)
+	}
+
+	return nil
+}
+
+// ── CLI filter flag names ──
+
+const (
+	FlagCategory      = "--category"
+	FlagAction        = "--action"
+	FlagNode          = "--node"
+	FlagTarget        = "--target"
+	FlagComponent     = "--component"
+	FlagPool          = "--pool"
+	FlagVolume        = "--volume"
+	FlagReplica       = "--replica"
+	FlagRebuildStatus = "--rebuild-status"
+	FlagState         = "--state"
+	FlagFilter        = "--filter"
+	FlagSince         = "--since"
+	FlagLimit         = "--limit"
+	FlagLokiEndpoint  = "--loki-endpoint"
+	FlagOutputFormat  = "-o"
+)
+
+// ── CLI filter values (kebab-case — passed to --category, --action, etc.) ──
+
+const (
+	FilterCategoryPool             = "pool"
+	FilterCategoryVolume           = "volume"
+	FilterCategoryNexus            = "nexus"
+	FilterCategoryReplica          = "replica"
+	FilterCategoryNode             = "node"
+	FilterCategoryHighAvailability = "high-availability"
+	FilterCategoryNvmePath         = "nvme-path"
+	FilterCategoryHostInitiator    = "host-initiator"
+	FilterCategoryIoEngine         = "io-engine-category"
+	FilterCategorySnapshot         = "snapshot"
+	FilterCategoryClone            = "clone"
+)
+
+const (
+	FilterActionCreate               = "create"
+	FilterActionDelete               = "delete"
+	FilterActionStateChange          = "state-change"
+	FilterActionRebuildBegin         = "rebuild-begin"
+	FilterActionRebuildEnd           = "rebuild-end"
+	FilterActionSwitchOver           = "switch-over"
+	FilterActionAddChild             = "add-child"
+	FilterActionRemoveChild          = "remove-child"
+	FilterActionOnlineChild          = "online-child"
+	FilterActionNvmePathSuspect      = "nvme-path-suspect"
+	FilterActionNvmePathFail         = "nvme-path-fail"
+	FilterActionNvmePathFix          = "nvme-path-fix"
+	FilterActionNvmeConnect          = "nvme-connect"
+	FilterActionNvmeDisconnect       = "nvme-disconnect"
+	FilterActionNvmeKeepAliveTimeout = "nvme-keep-alive-timeout"
+	FilterActionReactorFreeze        = "reactor-freeze"
+	FilterActionReactorUnfreeze      = "reactor-unfreeze"
+	FilterActionShutdown             = "shutdown"
+	FilterActionStart                = "start"
+	FilterActionStop                 = "stop"
+	FilterActionSubsystemPause       = "subsystem-pause"
+	FilterActionSubsystemResume      = "subsystem-resume"
+	FilterActionInit                 = "init"
+	FilterActionReconfiguring        = "reconfiguring"
+	FilterActionNvmePathDeleting     = "nvme-path-deleting"
+)
+
+const (
+	FilterComponentCoreAgent      = "core-agent"
+	FilterComponentIoEngine       = "io-engine"
+	FilterComponentHaClusterAgent = "ha-cluster-agent"
+	FilterComponentHaNodeAgent    = "ha-node-agent"
+)
+
+const (
+	FilterRebuildStatusStarted   = "started"
+	FilterRebuildStatusCompleted = "completed"
+	FilterRebuildStatusStopped   = "stopped"
+	FilterRebuildStatusFailed    = "failed"
+)
+
+// ── Output formats ──
+
+const (
+	OutputJSON  = "json"
+	OutputYAML  = "yaml"
+	OutputTable = "table"
+)

--- a/common/types.go
+++ b/common/types.go
@@ -643,3 +643,196 @@ type ZfsSpec struct {
 type ZfsStatus struct {
 	State string `json:"state"`
 }
+
+// ── Event enum types (PascalCase — values in JSON output) ──
+
+type EventCategory string
+
+const (
+	EventCategoryPool             EventCategory = "Pool"
+	EventCategoryVolume           EventCategory = "Volume"
+	EventCategoryNexus            EventCategory = "Nexus"
+	EventCategoryReplica          EventCategory = "Replica"
+	EventCategoryNode             EventCategory = "Node"
+	EventCategoryHighAvailability EventCategory = "HighAvailability"
+	EventCategoryNvmePath         EventCategory = "NvmePath"
+	EventCategoryHostInitiator    EventCategory = "HostInitiator"
+	EventCategoryIoEngine         EventCategory = "IoEngineCategory"
+	EventCategorySnapshot         EventCategory = "Snapshot"
+	EventCategoryClone            EventCategory = "Clone"
+)
+
+type EventAction string
+
+const (
+	EventActionCreate               EventAction = "Create"
+	EventActionDelete               EventAction = "Delete"
+	EventActionStateChange          EventAction = "StateChange"
+	EventActionRebuildBegin         EventAction = "RebuildBegin"
+	EventActionRebuildEnd           EventAction = "RebuildEnd"
+	EventActionSwitchOver           EventAction = "SwitchOver"
+	EventActionAddChild             EventAction = "AddChild"
+	EventActionRemoveChild          EventAction = "RemoveChild"
+	EventActionOnlineChild          EventAction = "OnlineChild"
+	EventActionNvmePathSuspect      EventAction = "NvmePathSuspect"
+	EventActionNvmePathFail         EventAction = "NvmePathFail"
+	EventActionNvmePathFix          EventAction = "NvmePathFix"
+	EventActionNvmeConnect          EventAction = "NvmeConnect"
+	EventActionNvmeDisconnect       EventAction = "NvmeDisconnect"
+	EventActionNvmeKeepAliveTimeout EventAction = "NvmeKeepAliveTimeout"
+	EventActionReactorFreeze        EventAction = "ReactorFreeze"
+	EventActionReactorUnfreeze      EventAction = "ReactorUnfreeze"
+	EventActionShutdown             EventAction = "Shutdown"
+	EventActionStart                EventAction = "Start"
+	EventActionStop                 EventAction = "Stop"
+	EventActionSubsystemPause       EventAction = "SubsystemPause"
+	EventActionSubsystemResume      EventAction = "SubsystemResume"
+	EventActionInit                 EventAction = "Init"
+	EventActionReconfiguring        EventAction = "Reconfiguring"
+	EventActionNvmePathDeleting     EventAction = "NvmePathDeleting"
+)
+
+type EventComponent string
+
+const (
+	EventComponentCoreAgent      EventComponent = "CoreAgent"
+	EventComponentIoEngine       EventComponent = "IoEngine"
+	EventComponentHaClusterAgent EventComponent = "HaClusterAgent"
+	EventComponentHaNodeAgent    EventComponent = "HaNodeAgent"
+)
+
+type RebuildStatus string
+
+const (
+	RebuildStatusStarted   RebuildStatus = "Started"
+	RebuildStatusCompleted RebuildStatus = "Completed"
+	RebuildStatusStopped   RebuildStatus = "Stopped"
+	RebuildStatusFailed    RebuildStatus = "Failed"
+)
+
+type SwitchOverStatus string
+
+const (
+	SwitchOverStarted   SwitchOverStatus = "SwitchOverStarted"
+	SwitchOverCompleted SwitchOverStatus = "SwitchOverCompleted"
+	SwitchOverFailed    SwitchOverStatus = "SwitchOverFailed"
+)
+
+type EventVersion string
+
+const (
+	EventVersionV1 EventVersion = "V1"
+)
+
+// ── Event struct types (mirrors kubectl mayastor get events -o json) ──
+
+type EventRecord struct {
+	Category EventCategory `json:"category"`
+	Action   EventAction   `json:"action"`
+	Target   string        `json:"target,omitempty"`
+	Metadata EventMeta     `json:"metadata"`
+}
+
+type EventMeta struct {
+	Id             string       `json:"id"`
+	Source         EventSource  `json:"source"`
+	EventTimestamp string       `json:"timestamp"`
+	Version        EventVersion `json:"version"`
+}
+
+type EventSource struct {
+	Component    EventComponent `json:"component"`
+	Node         string         `json:"node,omitempty"`
+	EventDetails *EventDetails  `json:"eventDetails,omitempty"`
+}
+
+type EventDetails struct {
+	RebuildDetails        *RebuildDetails        `json:"rebuildDetails,omitempty"`
+	SwitchOverDetails     *SwitchOverDetails     `json:"switchOverDetails,omitempty"`
+	NexusChildDetails     *NexusChildDetails     `json:"nexusChildDetails,omitempty"`
+	NvmePathDetails       *NvmePathDetails       `json:"nvmePathDetails,omitempty"`
+	HostInitiatorDetails  *HostInitiatorDetails  `json:"hostInitiatorDetails,omitempty"`
+	StateChangeDetails    *StateChangeDetails    `json:"stateChangeDetails,omitempty"`
+	ReplicaDetails        *ReplicaDetails        `json:"replicaDetails,omitempty"`
+	SnapshotDetails       *SnapshotDetails       `json:"snapshotDetails,omitempty"`
+	CloneDetails          *CloneDetails          `json:"cloneDetails,omitempty"`
+	SubsystemPauseDetails *SubsystemPauseDetails `json:"subsystemPauseDetails,omitempty"`
+	ActionDurationDetails *ActionDurationDetails  `json:"actionDurationDetails,omitempty"`
+	ReactorDetails        *ReactorDetails        `json:"reactorDetails,omitempty"`
+	ErrorDetails          *ErrorDetails          `json:"errorDetails,omitempty"`
+}
+
+type RebuildDetails struct {
+	RebuildStatus      RebuildStatus `json:"rebuildStatus"`
+	SourceReplica      string        `json:"sourceReplica"`
+	DestinationReplica string        `json:"destinationReplica"`
+	Error              string        `json:"error,omitempty"`
+}
+
+type SwitchOverDetails struct {
+	SwitchOverStatus SwitchOverStatus `json:"switchOverStatus"`
+	StartTime        string           `json:"startTime"`
+	ExistingNqn      string           `json:"existingNqn"`
+	NewPath          string           `json:"newPath,omitempty"`
+	RetryCount       uint64           `json:"retryCount,omitempty"`
+}
+
+type NexusChildDetails struct {
+	Uri string `json:"uri"`
+}
+
+type NvmePathDetails struct {
+	Nqn  string `json:"nqn"`
+	Path string `json:"path"`
+}
+
+type HostInitiatorDetails struct {
+	HostNqn      string `json:"hostNqn"`
+	SubsystemNqn string `json:"subsystemNqn"`
+	Target       string `json:"target"`
+	Uuid         string `json:"uuid"`
+}
+
+type StateChangeDetails struct {
+	Previous string `json:"previous"`
+	Next     string `json:"next"`
+}
+
+type ReplicaDetails struct {
+	PoolName    string `json:"poolName"`
+	PoolUuid    string `json:"poolUuid"`
+	ReplicaName string `json:"replicaName"`
+}
+
+type SnapshotDetails struct {
+	ReplicaId  string `json:"replicaId"`
+	CreateTime string `json:"createTime"`
+	VolumeId   string `json:"volumeId"`
+}
+
+type CloneDetails struct {
+	SourceUuid string `json:"sourceUuid"`
+	CreateTime string `json:"createTime"`
+}
+
+type SubsystemPauseDetails struct {
+	NexusPauseState string `json:"nexusPauseState"`
+}
+
+type ActionDurationDetails struct {
+	TimeTaken TimeDuration `json:"timeTaken"`
+}
+
+type TimeDuration struct {
+	Seconds uint64 `json:"seconds"`
+	Nanos   uint64 `json:"nanos"`
+}
+
+type ReactorDetails struct {
+	Lcore uint64 `json:"lcore"`
+	State string `json:"state"`
+}
+
+type ErrorDetails struct {
+	Error string `json:"error"`
+}

--- a/configurations/product/mayastor_config.yaml
+++ b/configurations/product/mayastor_config.yaml
@@ -32,6 +32,7 @@ product:
     helmReleaseName: "mayastor"
     ioEnginePodLabelValue: "io-engine"
     ioEnginePodName: "mayastor-io-engine"
+    eventingAggregatorDeployment: "mayastor-eventing-aggregator"
     jaegersCrdName: "jaegers.jaegertracing.io"
     kubectlPluginName: "kubectl-mayastor"
     kubectlPluginPort: 30011

--- a/scripts/e2e-cluster-dump.sh
+++ b/scripts/e2e-cluster-dump.sh
@@ -272,17 +272,3 @@ if [ "$podlogs" -ne 0 ]; then
     getSystemCmdOutputs "$destdir"
 fi
 
-function getEvents {
-    dest="$1"
-    event_collector_dir="${SCRIPT_DIR}/../src/tools/e2e_event_collector/"
-    if [ -d "${event_collector_dir}" ]; then
-    	outfile_json=$(realpath "$dest/events.json")
-    	outfile_yaml=$(realpath "$dest/events.yaml")
-        pushd ${event_collector_dir} > /dev/null \
-		&& go run e2e_event_collector.go -o json -f "${outfile_json}" \
-		&& go run e2e_event_collector.go -o yaml -f "${outfile_yaml}"; \
-		popd > /dev/null
-    fi
-}
-
-getEvents "$destdir"


### PR DESCRIPTION
- Replace NATS-based event collection with kubectl mayastor get events plugin infrastructure. Add typed EventRecord structs with Go enum types (EventCategory, EventAction, EventComponent, RebuildStatus, SwitchOverStatus, EventVersion) in common/types.go for compile-time type safety. 
- Add reusable helper functions in events/events.go
- Remove AfterEach NATS event collection from e2e_ginkgo.go and getEvents() from e2e-cluster-dump.sh — events are now collected via system dump.