### PR TITLE
fix(events): handle non-JSON plugin stdout prefix and add GetEventsWithStderr

### DIFF
--- a/common/controlplane/controlplane.go
+++ b/common/controlplane/controlplane.go
@@ -134,6 +134,7 @@ type ControlPlaneInterface interface {
 
 	// Events
 	GetEvents(flags ...string) ([]common.EventRecord, error)
+	GetEventsWithStderr(flags ...string) ([]common.EventRecord, string, error)
 	CountEvents(flags ...string) int
 }
 
@@ -535,6 +536,10 @@ func DeleteOfflineNodeViaPlugin(nodeName string, flags ...common.OfflinePoolDele
 
 func GetEvents(flags ...string) ([]common.EventRecord, error) {
 	return getControlPlane().GetEvents(flags...)
+}
+
+func GetEventsWithStderr(flags ...string) ([]common.EventRecord, string, error) {
+	return getControlPlane().GetEventsWithStderr(flags...)
 }
 
 func CountEvents(flags ...string) int {

--- a/common/controlplane/v1-rest-api/events.go
+++ b/common/controlplane/v1-rest-api/events.go
@@ -10,6 +10,10 @@ func (cp CPv1RestApi) GetEvents(flags ...string) ([]common.EventRecord, error) {
 	panic(fmt.Errorf("not implemented REST api"))
 }
 
+func (cp CPv1RestApi) GetEventsWithStderr(flags ...string) ([]common.EventRecord, string, error) {
+	panic(fmt.Errorf("not implemented REST api"))
+}
+
 func (cp CPv1RestApi) CountEvents(flags ...string) int {
 	panic(fmt.Errorf("not implemented REST api"))
 }

--- a/common/controlplane/v1/events.go
+++ b/common/controlplane/v1/events.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -8,6 +9,17 @@ import (
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+// extractJSON strips any non-JSON prefix the plugin may write to stdout
+// (e.g. "Loki is not found, continuing...") before the actual JSON array/object.
+func extractJSON(raw []byte) []byte {
+	for i, b := range raw {
+		if b == '[' || b == '{' {
+			return raw[i:]
+		}
+	}
+	return raw
+}
 
 func (cp CPv1) GetEvents(flags ...string) ([]common.EventRecord, error) {
 	args := append([]string{"get", "events", "-n", common.NSMayastor(), "-o", "json"}, flags...)
@@ -18,10 +30,38 @@ func (cp CPv1) GetEvents(flags ...string) ([]common.EventRecord, error) {
 		return nil, err
 	}
 	var records []common.EventRecord
-	if err := json.Unmarshal(jsonInput, &records); err != nil {
+	if err := json.Unmarshal(extractJSON(jsonInput), &records); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal events JSON: %w, output: %s", err, string(jsonInput))
 	}
 	return records, nil
+}
+
+// GetEventsWithStderr runs the plugin and captures stdout (JSON events) and stderr (warnings) separately.
+// Non-JSON prefix lines in stdout are captured in the returned stderr string.
+func (cp CPv1) GetEventsWithStderr(flags ...string) ([]common.EventRecord, string, error) {
+	args := append([]string{"get", "events", "-n", common.NSMayastor(), "-o", "json"}, flags...)
+	cmd := GetMayastorPluginCmd(args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	stdoutBytes := stdout.Bytes()
+	stderrStr := stderr.String()
+	// plugin may write informational messages to stdout before JSON;
+	// capture those as part of stderrStr so the caller can check them
+	jsonBytes := extractJSON(stdoutBytes)
+	if len(jsonBytes) < len(stdoutBytes) {
+		prefix := string(stdoutBytes[:len(stdoutBytes)-len(jsonBytes)])
+		stderrStr = prefix + stderrStr
+	}
+	if err != nil {
+		return nil, stderrStr, fmt.Errorf("plugin command failed: %w, stderr: %s", err, stderrStr)
+	}
+	var records []common.EventRecord
+	if err := json.Unmarshal(jsonBytes, &records); err != nil {
+		return nil, stderrStr, fmt.Errorf("failed to unmarshal events JSON: %w, output: %s", err, stdout.String())
+	}
+	return records, stderrStr, nil
 }
 
 func (cp CPv1) CountEvents(flags ...string) int {

--- a/common/mayastor/events/events.go
+++ b/common/mayastor/events/events.go
@@ -93,6 +93,11 @@ func WithLimit(limit int) FilterOption {
 	return func() []string { return []string{FlagLimit, strconv.Itoa(limit)} }
 }
 
+// WithLokiEndpoint adds --loki-endpoint flag to force a specific Loki URL (hard error if unreachable).
+func WithLokiEndpoint(endpoint string) FilterOption {
+	return func() []string { return []string{FlagLokiEndpoint, endpoint} }
+}
+
 // BuildFlags collects all FilterOption functions into a flat slice of CLI flag pairs.
 func BuildFlags(opts ...FilterOption) []string {
 	var flags []string
@@ -107,6 +112,11 @@ func BuildFlags(opts ...FilterOption) []string {
 // GetEvents queries the plugin for events matching the given filters and returns them newest-first.
 func GetEvents(opts ...FilterOption) ([]common.EventRecord, error) {
 	return controlplane.GetEvents(BuildFlags(opts...)...)
+}
+
+// GetEventsWithStderr queries the plugin and returns events plus the raw stderr output (warnings).
+func GetEventsWithStderr(opts ...FilterOption) ([]common.EventRecord, string, error) {
+	return controlplane.GetEventsWithStderr(BuildFlags(opts...)...)
 }
 
 // EventsCount returns the number of events matching the given filters.


### PR DESCRIPTION
The plugin may write informational messages to stdout before the JSON output (e.g. Loki is not found, continuing...), breaking json.Unmarshal. Add extractJSON() to strip non-JSON prefix before parsing. Add GetEventsWithStderr to capture stdout and stderr. Add WithLokiEndpoint filter option and doc comments to all exported functions in events.go.