### PR TITLE
chore:  bump pinned actions off deprecated Node.js 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,11 @@ jobs:
   k8s-ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v11
+      - uses: actions/checkout@v7
+      - uses: DeterminateSystems/nix-installer-action@v22
         with:
           kvm: true
-      - uses: DeterminateSystems/magic-nix-cache-action@v6
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
       - name: Pre-populate nix-shell
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
@@ -22,7 +22,7 @@ jobs:
           nix-shell shell.nix --run "./scripts/go-checks.sh"
       - name: BootStrap k8s cluster
         run: |
-          nix-shell shell.nix --run "./scripts/k8s/deployer.sh start --workers 1 --zfs --lvm" 
+          nix-shell shell.nix --run "./scripts/k8s/deployer.sh start --workers 1 --zfs --lvm"
       - name: E2E smoke test
         run: |
           nix-shell shell.nix --run "./scripts/e2e-test.sh --testplan selfci"

--- a/.github/workflows/debug-e2e-test.yml
+++ b/.github/workflows/debug-e2e-test.yml
@@ -17,11 +17,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v11
+      - uses: actions/checkout@v7
+      - uses: DeterminateSystems/nix-installer-action@v22
         with:
           kvm: true
-      - uses: DeterminateSystems/magic-nix-cache-action@v6
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
       - name: Pre-populate nix-shell
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
@@ -34,11 +34,11 @@ jobs:
     needs: ['lint']
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v11
+      - uses: actions/checkout@v7
+      - uses: DeterminateSystems/nix-installer-action@v22
         with:
           kvm: true
-      - uses: DeterminateSystems/magic-nix-cache-action@v6
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
       - name: Pre-populate nix-shell
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
@@ -59,11 +59,11 @@ jobs:
     needs: ['lint']
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v11
+      - uses: actions/checkout@v7
+      - uses: DeterminateSystems/nix-installer-action@v22
         with:
           kvm: true
-      - uses: DeterminateSystems/magic-nix-cache-action@v6
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
       - name: Pre-populate nix-shell
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)

--- a/.github/workflows/e2e-test-develop.yml
+++ b/.github/workflows/e2e-test-develop.yml
@@ -7,11 +7,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v11
+      - uses: actions/checkout@v7
+      - uses: DeterminateSystems/nix-installer-action@v22
         with:
           kvm: true
-      - uses: DeterminateSystems/magic-nix-cache-action@v6
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
       - name: Pre-populate nix-shell
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
@@ -24,11 +24,11 @@ jobs:
     needs: ['lint']
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v11
+      - uses: actions/checkout@v7
+      - uses: DeterminateSystems/nix-installer-action@v22
         with:
           kvm: true
-      - uses: DeterminateSystems/magic-nix-cache-action@v6
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
       - name: Pre-populate nix-shell
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
@@ -44,11 +44,11 @@ jobs:
     needs: ['lint']
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v11
+      - uses: actions/checkout@v7
+      - uses: DeterminateSystems/nix-installer-action@v22
         with:
           kvm: true
-      - uses: DeterminateSystems/magic-nix-cache-action@v6
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
       - name: Pre-populate nix-shell
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
@@ -64,11 +64,11 @@ jobs:
     needs: ['lint']
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v11
+      - uses: actions/checkout@v7
+      - uses: DeterminateSystems/nix-installer-action@v22
         with:
           kvm: true
-      - uses: DeterminateSystems/magic-nix-cache-action@v6
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
       - name: Pre-populate nix-shell
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -17,11 +17,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v11
+      - uses: actions/checkout@v7
+      - uses: DeterminateSystems/nix-installer-action@v22
         with:
           kvm: true
-      - uses: DeterminateSystems/magic-nix-cache-action@v6
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
       - name: Pre-populate nix-shell
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
@@ -34,11 +34,11 @@ jobs:
     needs: ['lint']
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v11
+      - uses: actions/checkout@v7
+      - uses: DeterminateSystems/nix-installer-action@v22
         with:
           kvm: true
-      - uses: DeterminateSystems/magic-nix-cache-action@v6
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
       - name: Pre-populate nix-shell
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
@@ -54,11 +54,11 @@ jobs:
     needs: ['lint']
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v11
+      - uses: actions/checkout@v7
+      - uses: DeterminateSystems/nix-installer-action@v22
         with:
           kvm: true
-      - uses: DeterminateSystems/magic-nix-cache-action@v6
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
       - name: Pre-populate nix-shell
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
@@ -74,11 +74,11 @@ jobs:
     needs: ['lint']
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v11
+      - uses: actions/checkout@v7
+      - uses: DeterminateSystems/nix-installer-action@v22
         with:
           kvm: true
-      - uses: DeterminateSystems/magic-nix-cache-action@v6
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
       - name: Pre-populate nix-shell
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -8,7 +8,7 @@ jobs:
   fossa-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
       - uses: fossas/fossa-action@v1.4.0


### PR DESCRIPTION
actions/checkout@v4, nix-installer-action@v11, and magic-nix-cache-action@v6 all declare `using: node20`, so GitHub's
runner now force-runs them on Node 24 instead. Bump to the first major of each that ships a node24 action.yml (checkout@v7,nix-installer-action@v22, magic-nix-cache-action@v14) across all workflow files.